### PR TITLE
Remove deprecated __int__ warning

### DIFF
--- a/python/ecl/ecl_util.py
+++ b/python/ecl/ecl_util.py
@@ -91,10 +91,13 @@ EclUnitTypeEnum.addEnum("ECL_PVT_M_UNITS", 4)
 #-----------------------------------------------------------------
 
 class EclFileFlagEnum(BaseCEnum):
-    TYPE_NAME="ecl_file_flag_enum"
+    TYPE_NAME = "ecl_file_flag_enum"
+    ECL_FILE_DEFAULT = None
     ECL_FILE_CLOSE_STREAM = None
     ECL_FILE_WRITABLE = None
 
+
+EclFileFlagEnum.addEnum("ECL_FILE_DEFAULT", 0)
 EclFileFlagEnum.addEnum("ECL_FILE_CLOSE_STREAM", 1)
 EclFileFlagEnum.addEnum("ECL_FILE_WRITABLE", 2)
 

--- a/python/ecl/eclfile/ecl_file.py
+++ b/python/ecl/eclfile/ecl_file.py
@@ -45,9 +45,10 @@ from cwrap import BaseCClass
 from ecl import EclPrototype
 from ecl.util.util import CTime
 from ecl.util.util import monkey_the_camel
-from ecl import EclFileFlagEnum
-from ecl import EclFileEnum
+from ecl import EclFileFlagEnum, EclFileEnum
 from ecl.eclfile import EclKW, EclFileView
+
+ECL_FILE_DEFAULT = EclFileFlagEnum.ECL_FILE_DEFAULT
 
 
 class EclFile(BaseCClass):
@@ -183,8 +184,7 @@ class EclFile(BaseCClass):
         wr = ', read/write' if self._writable() else ''
         return self._create_repr('"%s"%s' % (fn,wr))
 
-
-    def __init__( self , filename , flags = 0 , index_filename = None):
+    def __init__(self, filename, flags=ECL_FILE_DEFAULT, index_filename=None):
         """
         Loads the complete file @filename.
 
@@ -706,11 +706,12 @@ class EclFileContextManager(object):
         return False
 
 
-def openEclFile( file_name , flags = 0):
+def openEclFile(file_name, flags=ECL_FILE_DEFAULT):
     print('The function openEclFile is deprecated, use open_ecl_file.')
     return open_ecl_file(file_name, flags)
 
-def open_ecl_file(file_name, flags=0):
+
+def open_ecl_file(file_name, flags=ECL_FILE_DEFAULT):
     return EclFileContextManager(EclFile(file_name, flags))
 
 

--- a/python/ecl/eclfile/ecl_file.py
+++ b/python/ecl/eclfile/ecl_file.py
@@ -45,13 +45,14 @@ from cwrap import BaseCClass
 from ecl import EclPrototype
 from ecl.util.util import CTime
 from ecl.util.util import monkey_the_camel
+from ecl import EclFileFlagEnum
 from ecl import EclFileEnum
 from ecl.eclfile import EclKW, EclFileView
 
 
 class EclFile(BaseCClass):
     TYPE_NAME = "ecl_file"
-    _open                        = EclPrototype("void*       ecl_file_open( char* , int )" , bind = False)
+    _open                        = EclPrototype("void*       ecl_file_open( char* , ecl_file_flag_enum )" , bind = False)
     _get_file_type               = EclPrototype("ecl_file_enum ecl_util_get_file_type( char* , bool* , int*)" , bind = False)
     _writable                    = EclPrototype("bool        ecl_file_writable( ecl_file )")
     _save_kw                     = EclPrototype("void        ecl_file_save_kw( ecl_file , ecl_kw )")


### PR DESCRIPTION
Protoyping with an int instead of the expected enum results in a deprecated __int__ warning on newer Python version. This should resolve #733 