### PR TITLE
Find libecl.dll on Windows

### DIFF
--- a/python/ecl/__init__.py
+++ b/python/ecl/__init__.py
@@ -84,6 +84,8 @@ if not ECL_LEGACY_INSTALLED:
             path = os.path.join(path, "libecl.so")
         elif platform.system() == "Darwin":
             path = os.path.join(path, "libecl.dylib")
+        elif platform.system() == "Windows":
+            path = os.path.join(os.path.dirname(__file__), ".bin", "libecl.dll")
         else:
             raise NotImplementedError("Invalid platform")
 


### PR DESCRIPTION
It seems like when installed from a wheel (built manually, as it is missing from pypi), it is not possible to load package on Windows, due to platform being not listed.
