### PR TITLE
Fix EclGrid.create_3d

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -4,6 +4,7 @@ copy_test_files () {
     ln -s {$CI_SOURCE_ROOT,$PWD}/bin
     ln -s {$CI_SOURCE_ROOT,$PWD}/lib
     ln -s {$CI_SOURCE_ROOT,$PWD}/test-data
+    ln -s -T $EQUINOR_TEST_DATA_ROOT  test-data/Equinor
     cp -R {$CI_SOURCE_ROOT,$PWD}/python/tests
     popd
 }

--- a/python/ecl/grid/ecl_grid.py
+++ b/python/ecl/grid/ecl_grid.py
@@ -1132,11 +1132,9 @@ class EclGrid(BaseCClass):
                 for i in range(kwa.size):
                     array[i] = kwa[i]
             else:
-                data_index = 0
                 for global_index in range(self.getGlobalSize()):
-                    if self.active(global_index=global_index):
-                        array[global_index] = kwa[data_index]
-                        data_index += 1
+                    active_index = self._get_active_index1(global_index)
+                    array[global_index] = kwa[active_index]
 
             array = array.reshape([self.getNX(), self.getNY(), self.getNZ()], order='F')
             return array

--- a/python/tests/ecl_tests/test_grid_equinor_coarse.py
+++ b/python/tests/ecl_tests/test_grid_equinor_coarse.py
@@ -23,20 +23,22 @@ from tests import EclTest, equinor_test
 
 @equinor_test()
 class GridCoarceTest(EclTest):
+    def lgc_grid(self):
+        return EclGrid(
+            self.createTestPath("Equinor/ECLIPSE/LGCcase/LGC_TESTCASE2.EGRID")
+        )
 
-    def test_coarse(self):
-        #work_area = TestArea("python/grid-test/testCoarse")
+    def test_save_roundtrip(self):
         with TestAreaContext("python/grid-test/testCoarse"):
-            testGRID = True
-            g1 = EclGrid(self.createTestPath("Equinor/ECLIPSE/LGCcase/LGC_TESTCASE2.EGRID"))
+            g1 = self.lgc_grid()
 
             g1.save_EGRID("LGC.EGRID")
             g2 = EclGrid("LGC.EGRID")
             self.assertTrue(g1.equal(g2, verbose=True))
+            self.assertEqual(g1.coarse_groups(), g2.coarse_groups())
 
-            if testGRID:
-                g1.save_GRID("LGC.GRID")
-                g3 = EclGrid("LGC.GRID")
-                self.assertTrue(g1.equal(g3, verbose=True))
+    def test_lgc_number_of_groups(self):
+        with TestAreaContext("python/grid-test/testCoarse"):
+            g1 = self.lgc_grid()
 
             self.assertTrue(g1.coarse_groups() == 3384)

--- a/python/tests/ecl_tests/test_restart.py
+++ b/python/tests/ecl_tests/test_restart.py
@@ -91,11 +91,6 @@ class RestartTest(EclTest):
         rlist0 = [0]
         self.report_list_file_test(self.xfile0, rlist0)
 
-        f = EclFile(self.grid_file)
-        with self.assertRaises(ArgumentError): #argumentError wraps the expected TypeError
-            EclFile.file_report_list(f)
-
-
     def test_dates(self):
         f = EclFile(self.u_file)
         dates = f.dates

--- a/python/tests/ecl_tests/test_rft_equinor.py
+++ b/python/tests/ecl_tests/test_rft_equinor.py
@@ -77,7 +77,9 @@ class RFTTest(EclTest):
 
 
     def test_basics(self):
-        wt = WellTrajectory(self.createTestPath("Equinor/ert-equinor/spotfire/gendata_rft_zone/E-3H.txt"))
+        wt = WellTrajectory(
+            self.createTestPath("Equinor/spotfire/gendata_rft_zone/E-3H.txt")
+        )
         self.assertEqual(len(wt), 38)
         self.assertTrue(isinstance(str(wt), str))
         self.assertTrue(isinstance(repr(wt), str))
@@ -88,12 +90,22 @@ class RFTTest(EclTest):
             WellTrajectory("/does/no/exist")
 
         with self.assertRaises(UserWarning):
-            WellTrajectory(self.createTestPath("Equinor/ert-equinor/spotfire/gendata_rft_zone/invalid_float.txt"))
+            WellTrajectory(
+                self.createTestPath(
+                    "Equinor/spotfire/gendata_rft_zone/invalid_float.txt"
+                )
+            )
 
         with self.assertRaises(UserWarning):
-            WellTrajectory(self.createTestPath("Equinor/ert-equinor/spotfire/gendata_rft_zone/missing_item.txt"))
+            WellTrajectory(
+                self.createTestPath(
+                    "Equinor/spotfire/gendata_rft_zone/missing_item.txt"
+                )
+            )
 
-        wt = WellTrajectory(self.createTestPath("Equinor/ert-equinor/spotfire/gendata_rft_zone/E-3H.txt"))
+        wt = WellTrajectory(
+            self.createTestPath("Equinor/spotfire/gendata_rft_zone/E-3H.txt")
+        )
         self.assertEqual(len(wt), 38)
 
         with self.assertRaises(IndexError):
@@ -111,7 +123,9 @@ class RFTTest(EclTest):
 
 
     def test_PLT(self):
-        rft_file = EclRFTFile(self.createTestPath("Equinor/ECLIPSE/Heidrun/RFT/2C3_MR61.RFT"))
+        rft_file = EclRFTFile(
+            self.createTestPath("Equinor/ECLIPSE/Heidrun/RFT/2C3_MR61.RFT")
+        )
 
         rft0 = rft_file[0]
         rft1 = rft_file[1]


### PR DESCRIPTION
There was an issue where create_3d would not correctly handle keywords
containing only active values for coarse groups. This seems to be
because the mapping between global index and active index is no longer
valid for the kind of assignment done in create_3d. The fix is to look
up the active index.

As coarse groups are only tested on internal data. Testing of internal data is added on PRs.