### PR TITLE
Run the c tests on komodo pr

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -1,6 +1,6 @@
 build_and_run_ctest () {
     pushd $CI_TEST_ROOT
-    cmake $CI_SOURCE_ROOT  -DBUILD_TESTS=ON -DEQUINOR_TESTDATA_ROOT=$EQUINOR_TESTDATA_ROOT
+    cmake $CI_SOURCE_ROOT  -DBUILD_TESTS=ON -DEQUINOR_TESTDATA_ROOT=$EQUINOR_TESTDATA_ROOT/ecl
     cmake --build .
     ctest --output-on-failure
     popd

--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -1,3 +1,13 @@
+build_and_run_ctest () {
+    pushd $CI_TEST_ROOT
+    cmake $CI_SOURCE_ROOT  -DBUILD_TESTS=ON
+    cmake --build .
+    ctest --output-on-failure
+    popd
+    # Reset
+    rm -rf $CI_TEST_ROOT
+    mkdir -p $CI_TEST_ROOT
+}
 copy_test_files () {
     pushd $CI_TEST_ROOT
     mkdir -p {.git,python}
@@ -7,4 +17,16 @@ copy_test_files () {
     ln -s -T $EQUINOR_TEST_DATA_ROOT  test-data/Equinor
     cp -R {$CI_SOURCE_ROOT,$PWD}/python/tests
     popd
+}
+run_tests () {
+    if [[ ! -z "${CI_PR_RUN:-}" ]]
+    then
+        pip install .
+    fi
+    ci_install_cmake
+    build_and_run_ctest
+    copy_test_files
+    install_test_dependencies
+    cd $CI_TEST_ROOT
+    pytest -vv
 }

--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -1,6 +1,6 @@
 build_and_run_ctest () {
     pushd $CI_TEST_ROOT
-    cmake $CI_SOURCE_ROOT  -DBUILD_TESTS=ON
+    cmake $CI_SOURCE_ROOT  -DBUILD_TESTS=ON -DEQUINOR_TESTDATA_ROOT=$EQUINOR_TESTDATA_ROOT
     cmake --build .
     ctest --output-on-failure
     popd
@@ -14,7 +14,6 @@ copy_test_files () {
     ln -s {$CI_SOURCE_ROOT,$PWD}/bin
     ln -s {$CI_SOURCE_ROOT,$PWD}/lib
     ln -s {$CI_SOURCE_ROOT,$PWD}/test-data
-    ln -s -T $EQUINOR_TEST_DATA_ROOT  test-data/Equinor
     cp -R {$CI_SOURCE_ROOT,$PWD}/python/tests
     popd
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -484,12 +484,12 @@ add_test(NAME ecl_grid_layer_contains2 COMMAND ecl_grid_layer_contains
 add_test(NAME ecl_restart_test COMMAND ecl_restart_test
     ${_eclpath}/Gurbat/ECLIPSE.UNRST)
 
-add_test(NAME ecl_nnc_export1 COMMAND ecl_nnc_export ${_eclpath}/Gurbat/ECLIPSE TRUE)
-add_test(NAME ecl_nnc_export2 COMMAND ecl_nnc_export ${_eclpath}/10kcase/TEST10K_FLT_LGR_NNC TRUE)
-add_test(NAME ecl_nnc_export4 COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUAL_DIFF TRUE)
-add_test(NAME ecl_nnc_export5 COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUALPORO TRUE)
-add_test(NAME ecl_nnc_export6 COMMAND ecl_nnc_export ${_eclpath}/nestedLGRcase/TESTCASE_NESTEDLGR TRUE)
-add_test(NAME ecl_nnc_export7 COMMAND ecl_nnc_export ${_eclpath}/TYRIHANS/BASE20150218_MULTFLT FALSE)
+add_test(NAME ecl_nnc_export_gurbat COMMAND ecl_nnc_export ${_eclpath}/Gurbat/ECLIPSE TRUE)
+add_test(NAME ecl_nnc_export_10kcase COMMAND ecl_nnc_export ${_eclpath}/10kcase/TEST10K_FLT_LGR_NNC TRUE)
+add_test(NAME ecl_nnc_export_dual_poro_diff COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUAL_DIFF TRUE)
+add_test(NAME ecl_nnc_export_dual_poro COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUALPORO TRUE)
+add_test(NAME ecl_nnc_export_nested_lgr_case COMMAND ecl_nnc_export ${_eclpath}/nestedLGRcase/TESTCASE_NESTEDLGR TRUE)
+add_test(NAME ecl_nnc_export_tyrihans COMMAND ecl_nnc_export ${_eclpath}/TYRIHANS/BASE20150218_MULTFLT FALSE)
 
 add_test(NAME ecl_nnc_export_get_tran COMMAND ecl_nnc_export_get_tran
     ${_eclpath}/Troll/MSW_LGR/2BRANCHES-CCEWELLPATH-NEW-SCH-TUNED-AR3)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -486,7 +486,6 @@ add_test(NAME ecl_restart_test COMMAND ecl_restart_test
 
 add_test(NAME ecl_nnc_export1 COMMAND ecl_nnc_export ${_eclpath}/Gurbat/ECLIPSE TRUE)
 add_test(NAME ecl_nnc_export2 COMMAND ecl_nnc_export ${_eclpath}/10kcase/TEST10K_FLT_LGR_NNC TRUE)
-add_test(NAME ecl_nnc_export3 COMMAND ecl_nnc_export ${_eclpath}/Troll/MSW_LGR/2BRANCHES-CCEWELLPATH-NEW-SCH-TUNED-AR3 TRUE)
 add_test(NAME ecl_nnc_export4 COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUAL_DIFF TRUE)
 add_test(NAME ecl_nnc_export5 COMMAND ecl_nnc_export ${_eclpath}/DualPoro/DUALPORO TRUE)
 add_test(NAME ecl_nnc_export6 COMMAND ecl_nnc_export ${_eclpath}/nestedLGRcase/TESTCASE_NESTEDLGR TRUE)

--- a/lib/ecl/tests/ecl_fmt.cpp
+++ b/lib/ecl/tests/ecl_fmt.cpp
@@ -29,10 +29,20 @@ void test_content( const ecl::util::TestArea& ta , const char * src_file , bool 
   ta.copy_file(src_file);
   {
     char * base_name;
+    char * extension;
     bool fmt;
-    util_alloc_file_components( src_file , NULL , &base_name , NULL);
+
+    util_alloc_file_components( src_file , NULL , &base_name , &extension);
+    char * file_name = util_alloc_filename( NULL , base_name , extension );
+
+    util_copy_file(file_name, base_name);
+
     test_assert_true( ecl_util_fmt_file( base_name , &fmt ));
     test_assert_bool_equal( fmt , fmt_file );
+
+    free(file_name);
+    free(base_name);
+    free(extension);
   }
 }
 


### PR DESCRIPTION
Currently the komodo job is responsible for running the internal test data, so it must also run the c tests.
