### PR TITLE
Check ecl_sum data is not empty

### DIFF
--- a/lib/ecl/ecl_sum.cpp
+++ b/lib/ecl/ecl_sum.cpp
@@ -1040,7 +1040,11 @@ time_t ecl_sum_get_start_time( const ecl_sum_type * ecl_sum) {
 }
 
 time_t ecl_sum_get_end_time( const ecl_sum_type * ecl_sum) {
-  return ecl_sum_data_get_sim_end( ecl_sum->data );
+  try {
+    return ecl_sum_data_get_sim_end( ecl_sum->data );
+  } catch (std::out_of_range) {
+    return ecl_smspec_get_start_time( ecl_sum->smspec );
+  }
 }
 
 double ecl_sum_iget_sim_days( const ecl_sum_type * ecl_sum , int index ) {

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -365,6 +365,9 @@ bool ecl_sum_data_can_write(const ecl_sum_data_type * data) {
 }
 
 time_t ecl_sum_data_get_sim_end(const ecl_sum_data_type * data ) {
+  if (data->data_files.empty())
+    throw std::out_of_range("ecl_sum_data_get_sim_end: data_files empty");
+
   const auto& file_data = data->data_files.back();
   return file_data->get_sim_end();
 }

--- a/lib/ecl/ecl_sum_file_data.cpp
+++ b/lib/ecl/ecl_sum_file_data.cpp
@@ -251,6 +251,8 @@ time_t ecl_sum_file_data::get_data_start() const {
 
 
 time_t ecl_sum_file_data::get_sim_end() const {
+  if (this->index.size() == 0)
+    throw std::out_of_range("ecl_sum_file_data::get_sim_end(): index size is 0");
   const auto& node = this->index.back();
   return node.sim_time;
 }

--- a/python/tests/ecl_tests/test_ecl_sum.py
+++ b/python/tests/ecl_tests/test_ecl_sum.py
@@ -26,6 +26,13 @@ from ecl.summary import EclSum, EclSumKeyWordVector
 from ecl.util.test import TestAreaContext
 from tests import EclTest, equinor_test
 
+
+def test_write_repr():
+    """repr(EclSum) used to segfault when there is only a startdate"""
+    writer = EclSum.writer("TEST", datetime.date(2000, 2, 3), 10, 10, 10)
+    assert repr(writer).startswith('EclSum(name="writer", time=[2000-02-03 00:00:00, 2000-02-03 00:00:00], keys=0) at 0x')
+
+
 @equinor_test()
 class EclSumTest(EclTest):
 


### PR DESCRIPTION
Instead of changing the function prototype and thus breaking API, we
take advantage of the existing undefined behaviour when trying to grab
the last element of an empty dataset. We throw a C++ exception and then
catch it at the appropriate location. This does not modify the API or ABI.

Worked on this with @lars-petter-hauge 