### PR TITLE
Limit pytest to python/tests

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -27,5 +27,5 @@ run_tests () {
     copy_test_files
     install_test_dependencies
     cd $CI_TEST_ROOT
-    pytest -vv
+    pytest -vv python/tests
 }


### PR DESCRIPTION
Before pytest could look through test-data/Equinor which is
quite big and on disk.
