### PR TITLE
Remove big test data case flow-nnc

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -498,8 +498,7 @@ add_test(NAME ecl_nnc_export_get_tran COMMAND ecl_nnc_export_get_tran
 
 add_test(NAME ecl_nnc_data_equinor_root COMMAND ecl_nnc_data_equinor_root
     ${_eclpath}/Troll/MSW_LGR/2BRANCHES-CCEWELLPATH-NEW-SCH-TUNED-AR3
-    ${_eclpath}/flow-nnc/Simple4/SIMPLE_SUMMARY4
-    ${_eclpath}/flow-nnc/Gullfaks/GF_ACT_NEW_TEMP)
+    ${_eclpath}/flow-nnc/Simple4/SIMPLE_SUMMARY4)
 
 add_test(NAME ecl_sum_case_exists COMMAND ecl_sum_case_exists
          ${_eclpath}/Gurbat/ECLIPSE

--- a/lib/ecl/tests/ecl_nnc_data_equinor_root.cpp
+++ b/lib/ecl/tests/ecl_nnc_data_equinor_root.cpp
@@ -116,7 +116,6 @@ void test_alloc_file_flux(char * filename, int file_num) {
 
 int main(int argc , char ** argv) {
    test_alloc_file_tran(argv[1]);
-   test_alloc_file_flux(argv[2], 0);
-   test_alloc_file_flux(argv[2], 6);
+   test_alloc_file_flux(argv[1], 0);
    return 0;
 }


### PR DESCRIPTION
The flow-nnc/Gullfaks test data is responsible for half the size of the internal test-data set, which is considerable. Changed the test to use the flow-nnc/Simple4 testdata so that flow-nnc/Gullfaks can be removed.