### PR TITLE
Fix bug in util_alloc_cwd that would loop for ever

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -70,7 +70,7 @@ add_library(ecl util/rng.cpp
                 util/hash.cpp
                 util/node_data.cpp
                 util/node_ctype.cpp
-                util/util.c
+                util/util.cpp
                 util/util_symlink.cpp
                 util/util_lfs.c
                 util/util_unlink.cpp
@@ -214,7 +214,7 @@ if (NOT BUILD_TESTS)
 endif ()
 
 
-add_executable(ecl_test_suite tests/test_ecl_grid.cpp tests/test_ecl_util.cpp tests/testsuite.cpp)
+add_executable(ecl_test_suite tests/test_ecl_grid.cpp tests/test_ecl_util.cpp tests/testsuite.cpp tests/test_util.cpp)
 if (CMAKE_COMPILER_IS_GNUCC)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8)
         target_compile_options(ecl_test_suite PRIVATE -DFS_EXPERIMENTAL)

--- a/lib/tests/test_util.cpp
+++ b/lib/tests/test_util.cpp
@@ -1,0 +1,27 @@
+#include <catch2/catch.hpp>
+#include <ert/util/util.hpp>
+
+#include "tmpdir.hpp"
+
+using namespace Catch;
+using namespace Matchers;
+
+TEST_CASE_METHOD(Tmpdir, "Test getcwd after unlink cwd", "[unittest]") {
+    GIVEN("Test directory") {
+        auto subdir = dirname / "unlink";
+        fs::create_directory(subdir);
+        fs::current_path(subdir);
+
+        THEN("Use normally") {
+            auto path = util_alloc_cwd();
+            std::free(path);
+        }
+
+        THEN("Unlink") {
+            fs::remove(subdir);
+            CHECK_THROWS(util_alloc_cwd());
+        }
+
+        fs::current_path(dirname);
+    }
+}

--- a/lib/util/util.cpp
+++ b/lib/util/util.cpp
@@ -26,6 +26,8 @@
   manipulation functions which explicitly use the PATH_SEP variable.
 */
 
+#include <stdexcept>
+
 #include <assert.h>
 #include <string.h>
 #include <time.h>
@@ -693,21 +695,13 @@ static char * util_getcwd(char * buffer , int size) {
 
 
 char * util_alloc_cwd(void) {
-  char * result_ptr;
-  char * cwd;
-  int buffer_size = 128;
-  do {
-    cwd = (char*)util_calloc(buffer_size , sizeof * cwd );
-    result_ptr = util_getcwd(cwd , buffer_size - 1);
-    if (result_ptr == NULL) {
-      if (errno == ERANGE) {
-        buffer_size *= 2;
-        free(cwd);
-      }
-    }
-  } while ( result_ptr == NULL );
-  cwd = (char*)util_realloc(cwd , strlen(cwd) + 1 );
-  return cwd;
+  char cwd[PATH_MAX];
+  char * result_ptr = util_getcwd(cwd , sizeof(cwd));
+  if (result_ptr != NULL) {
+    return strdup(cwd);
+  } else {
+    throw std::runtime_error("Could not get cwd.");
+  }
 }
 
 


### PR DESCRIPTION
The code was assuming it could never fail to get cwd, but this is
actually possible in certain cases.

Remove the loop by allocating a large enough array to begin with,
and call util_abort, since the caller probably expects this to
always return a valid path.

**Issue**
Might solve  #648
