### PR TITLE
Fix EclInitFile using wrong default flag

### DIFF
--- a/python/ecl/eclfile/ecl_init_file.py
+++ b/python/ecl/eclfile/ecl_init_file.py
@@ -14,13 +14,14 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from ecl import EclFileEnum
-from ecl.eclfile import EclFile, Ecl3DFile
+from ecl import EclFileEnum, EclFileFlagEnum
+from ecl.eclfile import Ecl3DFile, EclFile
+
+ECL_FILE_DEFAULT = EclFileFlagEnum.ECL_FILE_DEFAULT
 
 
 class EclInitFile(Ecl3DFile):
-
-    def __init__(self, grid, filename, flags=0):
+    def __init__(self, grid, filename, flags=ECL_FILE_DEFAULT):
         file_type, report_step, fmt_file = EclFile.getFileType(filename)
         if file_type == EclFileEnum.ECL_INIT_FILE:
             super(EclInitFile, self).__init__(grid, filename, flags)

--- a/python/ecl/eclfile/ecl_restart_file.py
+++ b/python/ecl/eclfile/ecl_restart_file.py
@@ -15,12 +15,10 @@
 #  for more details.
 
 from cwrap import BaseCClass
+from ecl import EclFileEnum, EclFileFlagEnum, EclPrototype
+from ecl.eclfile import Ecl3DFile, EclFile
+from ecl.util.util import CTime, monkey_the_camel
 
-from ecl import EclPrototype
-from ecl.util.util import monkey_the_camel
-from ecl.util.util import CTime
-from ecl import EclFileEnum
-from ecl.eclfile import EclFile, Ecl3DFile, Ecl3DKW
 
 class EclRestartHead(BaseCClass):
     TYPE_NAME = "ecl_rsthead"
@@ -64,11 +62,11 @@ class EclRestartHead(BaseCClass):
                 "NCWMAX" : self._get_ncwmax()}
 
 
+ECL_FILE_DEFAULT = EclFileFlagEnum.ECL_FILE_DEFAULT
 
 
 class EclRestartFile(Ecl3DFile):
-
-    def __init__(self , grid , filename , flags = 0):
+    def __init__(self, grid, filename, flags=ECL_FILE_DEFAULT):
         """Will open an Eclipse restart file.
 
         The EclRestartFile class will open an eclipse restart file, in


### PR DESCRIPTION
EclFile has changed to use enum for flags, but EclInitFile still used default 0 which fails.
