### PR TITLE
Fix uninitialized header8

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -214,7 +214,7 @@ if (NOT BUILD_TESTS)
 endif ()
 
 
-add_executable(ecl_test_suite tests/test_ecl_grid.cpp tests/test_ecl_util.cpp tests/testsuite.cpp)
+add_executable(ecl_test_suite tests/test_ecl_kw.cpp tests/test_ecl_grid.cpp tests/test_ecl_util.cpp tests/testsuite.cpp)
 if (CMAKE_COMPILER_IS_GNUCC)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8)
         target_compile_options(ecl_test_suite PRIVATE -DFS_EXPERIMENTAL)

--- a/lib/ecl/ecl_kw.cpp
+++ b/lib/ecl/ecl_kw.cpp
@@ -16,6 +16,8 @@
    for more details.
 */
 
+#include <algorithm>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
@@ -43,7 +45,7 @@ struct ecl_kw_struct {
   UTIL_TYPE_ID_DECLARATION;
   int               size;
   ecl_data_type     data_type;
-  char            * header8;              /* Header which is right padded with ' ' to become exactly 8 characters long. Should only be used internally.*/
+  char              header8[9];           /* Header which is right padded with ' ' to become exactly 8 characters long. Should only be used internally.*/
   char            * header;               /* Header which is trimmed to no-space. */
   char            * data;                 /* The actual data vector. */
   bool              shared_data;          /* Whether this keyword has shared data or not. */
@@ -650,7 +652,7 @@ ecl_kw_type * ecl_kw_alloc_empty() {
 
   ecl_kw                 = (ecl_kw_type*)util_malloc(sizeof *ecl_kw );
   ecl_kw->header         = NULL;
-  ecl_kw->header8        = NULL;
+  ecl_kw->header8[8]     = '\0';
   ecl_kw->data           = NULL;
   ecl_kw->shared_data    = false;
   ecl_kw->size           = 0;
@@ -664,7 +666,6 @@ ecl_kw_type * ecl_kw_alloc_empty() {
 
 void ecl_kw_free(ecl_kw_type *ecl_kw) {
   free( ecl_kw->header );
-  free(ecl_kw->header8);
   ecl_kw_free_data(ecl_kw);
   free(ecl_kw);
 }
@@ -1528,37 +1529,12 @@ void ecl_kw_free_data(ecl_kw_type *ecl_kw) {
 }
 
 
-/**
- * copies src string into dest string with leading and
- * trailing whitespace removed.
- */
-char * strip(char * dest, const char *src) {
-  int strip_length = 0;
-  int end_index   = strlen(src) - 1;
-  while (end_index >= 0 && src[end_index] == ' ')
-    end_index--;
-
-  if (end_index >= 0) {
-
-    int start_index = 0;
-    while (src[start_index] == ' ')
-      start_index++;
-    strip_length = end_index - start_index + 1;
-    memcpy(dest , &src[start_index] , strip_length);
-  }
-  dest[strip_length] = '\0';
-}
-
 void ecl_kw_set_header_name(ecl_kw_type * ecl_kw , const char * header) {
-  size_t header_len = strlen(header);
-  ecl_kw->header8 = (char*)realloc(ecl_kw->header8 , ECL_STRING8_LENGTH + 1);
-  ecl_kw->header = (char*)realloc(ecl_kw->header , header_len + 1);
+  free(ecl_kw->header);
+  ecl_kw->header = strdup(header);
 
-  memset(ecl_kw->header8, ' ', ECL_STRING8_LENGTH);
-  ecl_kw->header8[ECL_STRING8_LENGTH] = '\0';
-  memcpy(ecl_kw->header8, header, ECL_STRING8_LENGTH < header_len ? ECL_STRING8_LENGTH: header_len);
-
-  strip(ecl_kw->header, header);
+  std::fill_n(ecl_kw->header8, 8, ' ');
+  std::copy_n(ecl_kw->header, std::min(strlen(header), static_cast<size_t>(8)), ecl_kw->header8);
 }
 
 

--- a/lib/ecl/ecl_kw.cpp
+++ b/lib/ecl/ecl_kw.cpp
@@ -1528,20 +1528,37 @@ void ecl_kw_free_data(ecl_kw_type *ecl_kw) {
 }
 
 
+/**
+ * copies src string into dest string with leading and
+ * trailing whitespace removed.
+ */
+char * strip(char * dest, const char *src) {
+  int strip_length = 0;
+  int end_index   = strlen(src) - 1;
+  while (end_index >= 0 && src[end_index] == ' ')
+    end_index--;
+
+  if (end_index >= 0) {
+
+    int start_index = 0;
+    while (src[start_index] == ' ')
+      start_index++;
+    strip_length = end_index - start_index + 1;
+    memcpy(dest , &src[start_index] , strip_length);
+  }
+  dest[strip_length] = '\0';
+}
 
 void ecl_kw_set_header_name(ecl_kw_type * ecl_kw , const char * header) {
+  size_t header_len = strlen(header);
   ecl_kw->header8 = (char*)realloc(ecl_kw->header8 , ECL_STRING8_LENGTH + 1);
-  if (strlen(header) <= 8) {
-     sprintf(ecl_kw->header8 , "%-8s" , header);
+  ecl_kw->header = (char*)realloc(ecl_kw->header , header_len + 1);
 
-     /* Internalizing a header without the trailing spaces as well. */
-     free( ecl_kw->header );
-     ecl_kw->header = util_alloc_strip_copy( ecl_kw->header8 );
-  }
-  else {
-     ecl_kw->header = (char*)util_alloc_copy(header, strlen( header ) + 1);
-  }
+  memset(ecl_kw->header8, ' ', ECL_STRING8_LENGTH);
+  ecl_kw->header8[ECL_STRING8_LENGTH] = '\0';
+  memcpy(ecl_kw->header8, header, ECL_STRING8_LENGTH < header_len ? ECL_STRING8_LENGTH: header_len);
 
+  strip(ecl_kw->header, header);
 }
 
 

--- a/lib/tests/test_ecl_kw.cpp
+++ b/lib/tests/test_ecl_kw.cpp
@@ -1,0 +1,43 @@
+
+#include <catch2/catch.hpp>
+#include <ert/ecl/ecl_kw.hpp>
+
+using namespace Catch;
+using namespace Matchers;
+
+TEST_CASE("Test header initilization", "[unittest]") {
+    GIVEN("A ecl_kw is created with a header longer than 8 characters"){
+        std::string header ="a_keyword_header_longer_than_8";
+        ecl_kw_type * kw = ecl_kw_alloc_new(header.c_str(), 3, ECL_FLOAT, NULL);
+        THEN("get_header returns the same name"){
+            REQUIRE(std::string(ecl_kw_get_header(kw)) == header);
+        }
+        THEN("get_header8 returns the first 8 characters of the name") {
+            REQUIRE(std::string(ecl_kw_get_header8(kw)) == header.substr(0,8));
+        }
+
+        WHEN("The header name is set"){
+            std::string other_header ="some_other_name";
+            ecl_kw_set_header_name(kw, other_header.c_str());
+
+            THEN("get_header returns the same name"){
+                REQUIRE(std::string(ecl_kw_get_header(kw)) == other_header);
+            }
+            THEN("get_header8 returns the first 8 characters of the name") {
+                REQUIRE(std::string(ecl_kw_get_header8(kw)) == other_header.substr(0,8));
+            }
+        }
+        ecl_kw_free(kw);
+    }
+    GIVEN("A ecl_kw is created with a header less than 8 characters"){
+        std::string header ="PORO";
+        ecl_kw_type * kw = ecl_kw_alloc_new(header.c_str(), 3, ECL_FLOAT, NULL);
+        THEN("get_header returns the same name"){
+            REQUIRE(std::string(ecl_kw_get_header(kw)) == header);
+        }
+        THEN("get_header8 returns a padded name") {
+            REQUIRE(std::string(ecl_kw_get_header8(kw)) == "PORO    ");
+        }
+        ecl_kw_free(kw);
+    }
+}

--- a/python/tests/ecl_tests/test_ecl_kw.py
+++ b/python/tests/ecl_tests/test_ecl_kw.py
@@ -37,6 +37,12 @@ def copy_offset():
     copy = src.sub_copy(200, 100)
 
 
+def test_ecl_kw_name():
+    name = "some_really_long_name" * 100
+    kw = EclKW(name, 3, EclDataType.ECL_INT)
+    assert kw.name == name
+
+
 class KWTest(EclTest):
 
     def test_name(self):


### PR DESCRIPTION
If a header longer than 8 characters is created header8 becomes uninitialized memory, making the python implementation crash completely. Changed it so that header8 is always the 8 first characters of the keyword header, while header is the entire string.

**Issue**
https://github.com/equinor/ecl/issues/775