### PR TITLE
Avoid sphinx 3.4.0 due to bug

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build ecl
       run: |
         mkdir cmake-build
-        cmake -S . -B cmake-build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake -S . -B cmake-build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRST_DOC=ON
         cmake --build cmake-build
 
     - name: Run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ scikit-build
 setuptools
 setuptools_scm
 six
-sphinx
+sphinx!=3.4.0
 wheel


### PR DESCRIPTION
ecl docs does not currently work with sphinx version 3.4.0, because of sphinx-doc/sphinx#8568