### PR TITLE
Avoid sphinx 3.4.0 due to breaking documentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ scikit-build
 setuptools
 setuptools_scm
 six
-sphinx
+sphinx!=3.4.0
 wheel


### PR DESCRIPTION
**Issue**
FMU documentation does not build anymore: https://github.com/equinor/fmu-docs/actions

**Approach**
Issue seems to be a problem with `sphinx==3.4.0` released two days ago: https://github.com/sphinx-doc/sphinx/issues/8568. Explicitly avoid that sphinx version...