### PR TITLE
Correct EclSum.get_days doc

### DIFF
--- a/python/ecl/summary/ecl_sum.py
+++ b/python/ecl/summary/ecl_sum.py
@@ -1070,13 +1070,13 @@ are advised to fetch vector as a numpy vector and then scale that yourself:
     @property
     def days(self):
         """
-        Will return a numpy vector of simulations days.
+        Will return a list of simulations days.
         """
         return self.get_days(False)
 
     def get_days(self, report_only=False):
         """
-        Will return a numpy vector of simulations days.
+        Will return a list of simulations days.
 
         If the optional argument @report_only is set to True, only
         'days' values corresponding to report steps will be included.


### PR DESCRIPTION
These functions return a list, but say they return a numpy vector. Corrected.

Resolves #799 
Resolves #800 