### PR TITLE
Fix EclSum.iget example in docs

### DIFF
--- a/python/ecl/summary/ecl_sum.py
+++ b/python/ecl/summary/ecl_sum.py
@@ -673,7 +673,7 @@ class EclSum(BaseCClass):
         from a well:
 
             for time_index in range(sum.length):
-                wwct = sum.iget(time_index, "WWCT:W5")
+                wwct = sum.iget("WWCT:W5", time_index)
 
         This is a quite low level function, in most cases it will be
         natural to go via e.g. an EclSumVector instance.


### PR DESCRIPTION
**Issue**
The order of the arguments was wrong in the documentation. Check vs implementation to verify that it is now correct.

**Approach**
Opened the file in vim, permuted the keywords, a `:wq` and some git usage and here we are 🤷 