### PR TITLE
Fix issues on Windows related to PATH_MAX and mkdir

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,26 @@
+name: Windows Compile
+
+on: [push, pull_request]
+
+jobs:
+  build-cmake:
+    name: CMake
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-latest']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # required for `git describe --tags` to work
+        fetch-depth: 0
+
+    - name: Build ecl
+      run: |
+        mkdir cmake-build
+        cmake -S . -B cmake-build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake --build cmake-build

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ __ecl_lib_info.py
 
 /dist
 /dist-*
+
+CMakeSettings.json

--- a/lib/util/util.cpp
+++ b/lib/util/util.cpp
@@ -79,6 +79,9 @@
 
 #ifdef HAVE_WINDOWS_GETCWD
 #include <direct.h>
+#ifndef PATH_MAX
+#define PATH_MAX _MAX_PATH
+#endif
 #endif
 
 
@@ -4657,12 +4660,12 @@ bool util_is_abs_path(const char * path) {
 }
 
 static int util_mkdir( const char * path ) {
+#ifdef HAVE_WINDOWS_MKDIR
+  return _mkdir( path );
+#else
 #ifdef HAVE_POSIX_MKDIR
   return mkdir( path , UTIL_DEFAULT_MKDIR_MODE );
 #endif
-
-#ifdef HAVE_WINDOWS_MKDIR
-  return _mkdir( path );
 #endif
 }
 


### PR DESCRIPTION
**Issue**
if Posix mkdir is detected, make sure that only one version of mkdir is used. Make sure PATH_MAX is defined
Add GitHub action for compile on Windows 
