### PR TITLE
Use time.perf_counter instead of time.clock

### DIFF
--- a/python/tests/ecl_tests/test_grid_equinor.py
+++ b/python/tests/ecl_tests/test_grid_equinor.py
@@ -207,9 +207,9 @@ class GridTest(EclTest):
         self.assertTrue(g1.equal(g2))
 
     def test_time(self):
-        t0 = time.clock()
+        t0 = time.perf_counter()
         g1 = EclGrid(self.egrid_file())
-        t1 = time.clock()
+        t1 = time.perf_counter()
         t = t1 - t0
         self.assertTrue(t < 1.0)
 


### PR DESCRIPTION
`time.clock` is deprecated and removed in Python 3.8. This has not been discovered since the internal tests are only running against Python 3.6 at the moment. 

**Approach**
Use `time.perf_counter` instead
