### PR TITLE
Update call to parent grid object

### DIFF
--- a/python/ecl/grid/cell.py
+++ b/python/ecl/grid/cell.py
@@ -60,7 +60,7 @@ class Cell(object):
 
     @property
     def fracture(self):
-        return self._grid.active_fracture_index(global_index=self._idx)
+        return self._grid.get_active_fracture_index(global_index=self._idx)
 
     @property
     def dz(self):


### PR DESCRIPTION
I was browsing through a `Cell` instance when noticed that call to `cell.fracture()` throws an error

```
>>> cells[0].fracture
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Miniconda3\lib\site-packages\ecl\grid\cell.py", line 63, in fracture
    return self._grid.active_fracture_index(global_index=self._idx)
AttributeError: 'EclGrid' object has no attribute 'active_fracture_index'
```

**Approach**
Seems like it should refer to `grid.get_active_fracture_index()` method.
