### PR TITLE
Simplify installation on corporate network

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build ecl
       run: |
         mkdir cmake-build
-        cmake -S . -B cmake-build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRST_DOC=ON
+        cmake -S . -B cmake-build -DBUILD_TESTS=ON -DRST_DOC=ON
         cmake --build cmake-build
 
     - name: Run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,29 @@ include(GNUInstallDirs)
 include(TestBigEndian)
 
 # -----------------------------------------------------------------
+# Set default CMAKE_BUILD_TYPE
+# -----------------------------------------------------------------
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE
+      "RelWithDebInfo"
+      CACHE STRING "CMake build type" FORCE)
+  message(
+    STATUS
+      "Setting CMake build type to ${CMAKE_BUILD_TYPE} as none was specified")
+
+  # Set possible values for use in cmake-gui
+  set(CACHE
+      CMAKE_BUILD_TYPE
+      PROPERTY
+      STRINGS
+      "Debug"
+      "Release"
+      "MinSizeRel"
+      "RelWithDebInfo")
+endif()
+
+# -----------------------------------------------------------------
 # Conan: C++ package manager
 # https://docs.conan.io/en/latest/howtos/cmake_launch.html
 # -----------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ Tool](http://github.com/Equinor/ert), other applications using
 *ecl* are the reservoir simulator flow and Resinsight from the [OPM
 project](http://github.com/OPM/).
 
+### Dependencies
+
+Regardless of how you build *ecl*, it will depend on the following system-level
+components.
+
+| Software                                           | Debian / Ubuntu | RHEL / Fedora | macOS                |
+|----------------------------------------------------|-----------------|---------------|----------------------|
+| `libz`                                             | `zlib1g-dev`    | `zlib-devel`  | _builtin_            |
+| [Conan](https://conan.io)                          | N/A             | N/A           | `conan` _(Homebrew)_ |
+| [pipx](https://pypi.org/project/pipx) _(Optional)_ | `pipx`          | `pipx`        | `pipx` _(Homebrew)_  |
+
+Note: The Conan package manager is not available for most Linux systems. Conan
+recommends installing it via `pip`. If using `pipx`, simply `pipx install conan`
+and it'll be availabe for your user regardless if you're using a virtualenv or
+not.
+
 ### Alternative 1: Python only ###
 For small interactive scripts, such as forward models, the recommended way to
 use *ecl* is by installing it from PyPI. This method doesn't require setting

--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -1,7 +1,6 @@
 build_and_run_ctest () {
     pushd $CI_TEST_ROOT
     cmake $CI_SOURCE_ROOT                                  \
-        -DCMAKE_BUILD_TYPE=Release                         \
         -DBUILD_TESTS=ON                                   \
         -DEQUINOR_TESTDATA_ROOT=$EQUINOR_TESTDATA_ROOT/ecl
     cmake --build .

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import skbuild
 import setuptools
@@ -5,6 +6,17 @@ from setuptools_scm import get_version
 
 
 version = get_version(relative_to=__file__, write_to="python/ecl/version.py")
+
+
+# Corporate networks tend to be behind a proxy server with their own non-public
+# SSL certificates. Conan keeps its own certificates, whose path we can override
+if "CONAN_CACERT_PATH" not in os.environ:
+    # Look for a RHEL-compatible system-wide file
+    for file_ in ("/etc/pki/tls/cert.pem",):
+        if not os.path.isfile(file_):
+            continue
+        os.environ["CONAN_CACERT_PATH"] = file_
+        break
 
 
 with open("README.md") as f:


### PR DESCRIPTION
This commit sets `CONAN_CACERT_PATH` to the RHEL system-wide
certificates path, if available.

We also modified the `CMakeLists.txt` to set `CMAKE_BUILD_TYPE` to
`RelWithDebInfo` so as to stop `conan.cmake` from complaining.

Resolves #833 