### PR TITLE
Avoid loss of precision when converting to double.

### DIFF
--- a/lib/ecl/ecl_sum_tstep.cpp
+++ b/lib/ecl/ecl_sum_tstep.cpp
@@ -170,7 +170,7 @@ static void ecl_sum_tstep_set_time_info(ecl_sum_tstep_type *tstep,
     time_t sim_start = ecl_smspec_get_start_time(smspec);
 
     if (sim_time_index >= 0) {
-        float sim_time = tstep->data[sim_time_index];
+        double sim_time = tstep->data[sim_time_index];
         double sim_seconds = sim_time * ecl_smspec_get_time_seconds(smspec);
         ecl_sum_tstep_set_time_info_from_seconds(tstep, sim_start, sim_seconds);
     } else if (date_day_index >= 0) {


### PR DESCRIPTION
**Issue**
Resolves #836

**Approach**
For some reason I cannot really explain, multiplying a float-value with an integer-value and then converting the result to double causes rounding. The loss of precision results in the small difference in sim_time when loading eagerly vs loading lazily seen in #836. Fix is to convert the float-value to double before multiplying.
