### PR TITLE
Use cmake_find_package conan generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(ecl C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules" "${CMAKE_CURRENT_BINARY_DIR}")
 
 include(GNUInstallDirs)
 include(TestBigEndian)
@@ -72,9 +73,8 @@ conan_cmake_run(
   # Build from source if there are no pre-compiled binaries
   BUILD
   missing
-  # CMAKE_TARGETS gives us CMake 3 style CONAN_PKG:: dependencies
-  BASIC_SETUP
-  CMAKE_TARGETS)
+  GENERATORS
+  cmake_find_package)
 
 # -----------------------------------------------------------------
 
@@ -235,12 +235,14 @@ if(MSVC)
   add_definitions("/W3 /D_CRT_SECURE_NO_WARNINGS /wd4996")
 endif()
 
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 find_package(CXX11Features)
 
 # -----------------------------------------------------------------
 
 # create targets for (required and optional) dependencies to link to
+
+find_package(Backward REQUIRED)
+find_package(fmt REQUIRED)
 
 find_package(OpenMP)
 if(NOT OPENMP_FOUND)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -148,7 +148,7 @@ endif()
 target_link_libraries(
   ecl
   PUBLIC ${m} ${dl} ${pthread} ${blas} ${zlib} ${shlwapi}
-  PRIVATE CONAN_PKG::backward-cpp CONAN_PKG::fmt)
+  PRIVATE Backward::Backward fmt::fmt)
 
 target_include_directories(
   ecl


### PR DESCRIPTION
A lot of packages provide additional functionality in their FindX.cmake
files. In our case, backward-cpp detects other unwinding libraries and
is capable of producing output similar to the following:

```
Abort called from: util_make_path (/home/zom/Scout/ecl/lib/util/util.cpp:4407)

Error message: util_make_path: failed to make directory:mnt/files - aborting
: No such file or directory(2)

--------------------------------------------------------------------------------
Stack trace (most recent call last):
        181: int main(int argc, char **argv) {
        182:     test_mount();
        183:     test_refcount();
      > 184:     test_read_only2();
        185:     test_block_fs_driver_create_fs();
        186:     exit(0);
        187: }
        161:         ecl::util::TestArea ta("ro2");
        162:         enkf_fs_create_fs("mnt", BLOCK_FS_DRIVER_ID, NULL, false);
        163:         pthread_mutex_lock(&data->mutex2);
      > 164:         createFS();
        165:         pthread_mutex_lock(&data->mutex1);
        166:         {
        167:             enkf_fs_type *fs_false = enkf_fs_mount("mnt");
        115:         test_assert_true(fs::exists("mnt/mnt.lock"));
        116:         pthread_mutex_unlock(&data->mutex1);
        117:         pthread_mutex_lock(&data->mutex2);
      > 118:         enkf_fs_decref(fs_false);
        119:         pthread_mutex_unlock(&data->mutex2);
        120:         exit(0);
        121:     }
    |   201:                    fs->mount_point, fs->refcount);
    |   202:     if (refcount == 0)
    | > 203:         enkf_fs_umount(fs);
    |   204:
    |   205:     return refcount;
      Source "/home/zom/Scout/ert/libres/lib/enkf/enkf_fs.cpp", line 558, in int enkf_fs_decref(enkf_fs_type *fs)
        556: static void enkf_fs_umount(enkf_fs_type *fs) {
        557:     if (!fs->read_only) {
      > 558:         enkf_fs_fsync(fs);
        559:         enkf_fs_fwrite_misfit(fs);
        560:     }
    |   616:     enkf_fs_fsync_time_map(fs);
    | > 617:     enkf_fs_fsync_cases_config(fs);
    |   618:     enkf_fs_fsync_state_map(fs);
    |   619:     enkf_fs_fsync_summary_key_set(fs);
      Source "/home/zom/Scout/ert/libres/lib/enkf/enkf_fs.cpp", line 409, in enkf_fs_fsync(enkf_fs_type *fs)
        407: static void enkf_fs_fsync_cases_config(enkf_fs_type *fs) {
        408:     char *filename = enkf_fs_alloc_case_filename(fs, CASE_CONFIG_FILE);
      > 409:     cases_config_fwrite(fs->cases_config, filename);
        410:     free(filename);
        411: }
         59: }
         60:
         61: void cases_config_fwrite(cases_config_type *config, const char *filename) {
      >  62:     FILE *stream = util_mkdir_fopen(filename, "w");
         63:     int iteration_no = cases_config_get_iteration_number(config);
         64:     util_fwrite_int(iteration_no, stream);
         65:     fclose(stream);
       3942:                 char *path;
       3943:                 util_alloc_file_components(filename, &path, NULL, NULL);
       3944:                 if (path != NULL) {
      >3945:                     util_make_path(path);
       3946:                     free(path);
       3947:                 }
       3948:             }
    |  4402: }
    |  4403:
    | >4404: void util_make_path(const char *path) {
    |  4405:     bool mkdir_ok = util_mkdir_p(path);
    |  4406:     if (!mkdir_ok)
      Source "/home/zom/Scout/ecl/lib/util/util.cpp", line 4407, in util_make_path(char *path)
       4404: void util_make_path(const char *path) {
       4405:     bool mkdir_ok = util_mkdir_p(path);
       4406:     if (!mkdir_ok)
      >4407:         util_abort("%s: failed to make directory:%s - aborting\n: %s(%d) \n",
       4408:                    __func__, path, strerror(errno), errno);
       4409: }
```

**Issue**
Resolves #<Issue id>

**Approach**
_Short description of the approach_
