### PR TITLE
Test to verify fix for #836

### DIFF
--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -670,6 +670,15 @@ class SumTest(EclTest):
         for time_index, value in enumerate(fopr):
             self.assertEqual(fopr[time_index], value)
 
+    def test_load_case_lazy_and_eager(self):
+        path = os.path.join(self.TESTDATA_ROOT, "local/ECLIPSE/cp_simple3/SHORT.UNSMRY")
+        lazy_dates = EclSum(path, lazy_load=True).numpy_dates
+        eager_dates = EclSum(path, lazy_load=False).numpy_dates
+        self.assertEqual(len(lazy_dates), 107)
+        self.assertEqual(len(eager_dates), 107)
+        for l, e in zip(lazy_dates, eager_dates):
+            self.assertEqual(l, e)
+
     def test_write_not_implemented(self):
         path = os.path.join(
             self.TESTDATA_ROOT, "local/ECLIPSE/cp_simple3/SIMPLE_SUMMARY3"


### PR DESCRIPTION
Extending existing test to verify the fix for https://github.com/equinor/ecl/issues/836.  

The existing testsuite already contains data exposing the issue. In order to verify that the testdata is relevant, reverse the fix and observe this test failing.
