### PR TITLE
Resolve deprecation of imp module by removal,  fix 3.10 compatibility

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,7 +13,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo pip install cmake-format black
+        sudo pip install cmake-format black==21.12b0
 
     - name: Clang Format
       run: ./script/clang-format --check

--- a/python/ecl/util/test/import_test_case.py
+++ b/python/ecl/util/test/import_test_case.py
@@ -15,21 +15,14 @@
 #  for more details.
 
 import importlib
-import os
-import sys
-import traceback
-import unittest
 import inspect
-import imp
+import os
+import unittest
 
 
 class ImportTestCase(unittest.TestCase):
-    def import_file(self, path):
-        return imp.load_source("module", path)
-
     def import_module(self, module):
-        mod = importlib.import_module(module)
-        return mod
+        return importlib.import_module(module)
 
     def import_package(self, package):
         if "__" in package:
@@ -42,7 +35,7 @@ class ImportTestCase(unittest.TestCase):
             entry_path = os.path.join(path, entry)
             if os.path.isdir(entry_path):
                 module = os.path.basename(entry)
-                sub_module = "%s.%s" % (package, module)
+                sub_module = f"{package}.{module}"
                 self.import_package(sub_module)
             else:
                 module, ext = os.path.splitext(entry)
@@ -50,6 +43,6 @@ class ImportTestCase(unittest.TestCase):
                     continue
 
                 if ext == "py":
-                    self.import_module("%s.%s" % (package, module))
+                    self.import_module(f"{package}.{module}")
 
         return True

--- a/python/tests/ecl_tests/test_grdecl.py
+++ b/python/tests/ecl_tests/test_grdecl.py
@@ -13,9 +13,10 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
+from numpy import allclose
+
 import cwrap
 from ecl.eclfile import EclKW
-from numpy.testing import assert_allclose
 
 
 def test_eclkw_read_grdecl(tmp_path):
@@ -33,4 +34,4 @@ def test_eclkw_read_grdecl(tmp_path):
 
     assert kw.get_name() == "COORD"
     assert len(kw.numpy_view()) == block_size * num_blocks
-    assert_allclose(kw.numpy_view(), value)
+    assert allclose(kw.numpy_view(), value)

--- a/python/tests/ecl_tests/test_grid.py
+++ b/python/tests/ecl_tests/test_grid.py
@@ -15,20 +15,18 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 import os.path
-import six
-from unittest import skipIf, skip
-import time
+from unittest import skip
 import itertools
-from numpy import linspace
+
+import six
+from numpy import linspace, allclose
 
 from ecl.util.util import IntVector
 from ecl import EclDataType, EclUnitTypeEnum
 from ecl.eclfile import EclKW, EclFile
 from ecl.grid import EclGrid
 from ecl.grid import EclGridGenerator as GridGen
-from ecl.grid.faults import Layer, FaultCollection
 from ecl.util.test import TestAreaContext
-from numpy.testing import assert_allclose
 from tests import EclTest
 
 # This dict is used to verify that corners are mapped to the correct
@@ -433,7 +431,7 @@ class GridTest(EclTest):
         numpy_3d = grid.create3D(kw1)
         kw2 = grid.create_kw(numpy_3d, "SWAT", False)
         self.assertEqual(kw2.name, "SWAT")
-        assert_allclose(grid.create3D(kw2), numpy_3d)
+        assert allclose(grid.create3D(kw2), numpy_3d)
 
     def test_create_3d_agrees_with_get_value(self):
         nx = 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,8 @@
 cwrap
-functools32;python_version=='2.7'
 future
 ninja
-numpy;python_version>='3.0'
-numpy<=1.16.6;python_version=='2.7'
-pandas;python_version>='3.0'
-pandas<=0.25.3;python_version=='2.7'
+numpy
+pandas
 scikit-build
 setuptools
 setuptools_scm


### PR DESCRIPTION
Cleanup PR:

* Pin black for Py36 compatibility
* Remove 2.7 remnants in requirements.txt
* Resolve deprecation warning by removing unused code
* Resolve py3.10 distutils incompatibility, use assert allclose.