### PR TITLE
Called with wrong arguments (don't explicitly pass self)

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,7 +13,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo pip install cmake-format black==21.12b0
+        sudo pip install cmake-format black==22.1.0 'click<8;python_version<="3.6"' 'click==8.0.2;python_version >"3.6"'
 
     - name: Clang Format
       run: ./script/clang-format --check

--- a/python/ecl/util/util/bool_vector.py
+++ b/python/ecl/util/util/bool_vector.py
@@ -26,7 +26,7 @@ class BoolVector(VectorTemplate):
         "bool_vector_obj string_util_alloc_active_mask( char* )", bind=False
     )
     _active_list = EclPrototype(
-        "int_vector_obj bool_vector_alloc_active_list(bool_vector)", bind=False
+        "int_vector_obj bool_vector_alloc_active_list(bool_vector)"
     )
     _alloc_copy = EclPrototype("bool_vector_obj bool_vector_alloc_copy( bool_vector )")
     _update_active_mask = EclPrototype(
@@ -110,7 +110,7 @@ class BoolVector(VectorTemplate):
 
     def count(self, value=True):
         """@rtype: int"""
-        return self._count_equal(self, value)
+        return self._count_equal(value)
 
     @classmethod
     def createActiveMask(cls, range_string):
@@ -155,7 +155,7 @@ class BoolVector(VectorTemplate):
 
     def createActiveList(self):
         """@rtype: ecl.util.IntVector"""
-        return self._active_list(self)
+        return self._active_list()
 
     def _tostr(self, arr=None):
         if arr is None:

--- a/python/ecl/well/well_connection.py
+++ b/python/ecl/well/well_connection.py
@@ -92,16 +92,19 @@ class WellConnection(BaseCClass):
         msw = " (multi segment)" if self.isMultiSegmentWell() else ""
         dir = WellConnectionDirectionEnum(self.direction())
         addr = self._address()
-        return "WellConnection(%s %s%s%s, rates = (O:%s,G:%s,W:%s), direction = %s) at 0x%x" % (
-            ijk,
-            frac,
-            open_,
-            msw,
-            self.oilRate(),
-            self.gasRate(),
-            self.waterRate(),
-            dir,
-            addr,
+        return (
+            "WellConnection(%s %s%s%s, rates = (O:%s,G:%s,W:%s), direction = %s) at 0x%x"
+            % (
+                ijk,
+                frac,
+                open_,
+                msw,
+                self.oilRate(),
+                self.gasRate(),
+                self.waterRate(),
+                dir,
+                addr,
+            )
         )
 
     def gasRate(self):

--- a/python/tests/ecl_tests/test_geertsma.py
+++ b/python/tests/ecl_tests/test_geertsma.py
@@ -209,8 +209,8 @@ class GeertsmaTest(EclTest):
                 "TEST",
                 p1,
                 p2,
-                rporv1=[10 ** 5, 10 ** 5],
-                rporv2=[9 * 10 ** 4, 9 * 10 ** 4],
+                rporv1=[10**5, 10**5],
+                rporv2=[9 * 10**4, 9 * 10**4],
             )
             create_init(grid, "TEST")
 

--- a/python/tests/ecl_tests/test_grid.py
+++ b/python/tests/ecl_tests/test_grid.py
@@ -552,7 +552,7 @@ class GridTest(EclTest):
 
         for x, y, z in itertools.product(range(0, n * d + 1, d), repeat=3):
             self.assertEqual(
-                1, [grid.cell_contains(x, y, z, i) for i in range(n ** 3)].count(True)
+                1, [grid.cell_contains(x, y, z, i) for i in range(n**3)].count(True)
             )
 
     def test_cell_corner_containment_compatability(self):
@@ -575,7 +575,7 @@ class GridTest(EclTest):
                 self.assertEqual(
                     1,
                     [
-                        grid.cell_contains(p[0], p[1], p[2], i) for i in range(n ** 3)
+                        grid.cell_contains(p[0], p[1], p[2], i) for i in range(n**3)
                     ].count(True),
                 )
 

--- a/python/tests/util_tests/test_vectors.py
+++ b/python/tests/util_tests/test_vectors.py
@@ -57,7 +57,7 @@ class UtilTest(TestCase):
         self.dotest_slicing(dv)
         iv = IntVector(initial_size=10)
         for i in range(10):
-            iv[i] = i ** 3
+            iv[i] = i**3
         self.dotest_slicing(iv)
         bv = BoolVector(initial_size=10)
         for i in range(0, 10, 3):
@@ -177,6 +177,8 @@ class UtilTest(TestCase):
         b[4] = False
 
         self.assertEqual(list(b), [True, True, True, True, False])
+        self.assertEqual(b.count(True), 4)
+        self.assertEqual(b.count(False), 1)
 
     def test_activeList(self):
         active_list = IntVector.active_list("1,10,100-105")
@@ -579,3 +581,15 @@ class UtilTest(TestCase):
         self.assertNotEqual(v1, v2)
         v2[3] = 99
         self.assertEqual(v1, v2)
+
+    def test_create_active_list(self):
+        vec = BoolVector(False, 10)
+        vec[0] = True
+        vec[3] = True
+        vec[7] = True
+
+        idxs = vec.createActiveList()
+        self.assertTrue(len(idxs) == 3, "Should get 3 indices")
+        self.assertEqual(idxs[0], 0)
+        self.assertEqual(idxs[1], 3)
+        self.assertEqual(idxs[2], 7)


### PR DESCRIPTION
The wrapped function `bool_vector_count_equal()` should not explicitly pass `self` since that is done implicitly. No idea why this works at all...