### PR TITLE
Fixes argument-bug in BoolVector and adds test

### DIFF
--- a/python/ecl/util/util/bool_vector.py
+++ b/python/ecl/util/util/bool_vector.py
@@ -26,7 +26,7 @@ class BoolVector(VectorTemplate):
         "bool_vector_obj string_util_alloc_active_mask( char* )", bind=False
     )
     _active_list = EclPrototype(
-        "int_vector_obj bool_vector_alloc_active_list(bool_vector)", bind=False
+        "int_vector_obj bool_vector_alloc_active_list(bool_vector)"
     )
     _alloc_copy = EclPrototype("bool_vector_obj bool_vector_alloc_copy( bool_vector )")
     _update_active_mask = EclPrototype(
@@ -110,7 +110,7 @@ class BoolVector(VectorTemplate):
 
     def count(self, value=True):
         """@rtype: int"""
-        return self._count_equal(self, value)
+        return self._count_equal(value)
 
     @classmethod
     def createActiveMask(cls, range_string):
@@ -155,7 +155,7 @@ class BoolVector(VectorTemplate):
 
     def createActiveList(self):
         """@rtype: ecl.util.IntVector"""
-        return self._active_list(self)
+        return self._active_list()
 
     def _tostr(self, arr=None):
         if arr is None:

--- a/python/tests/util_tests/test_vectors.py
+++ b/python/tests/util_tests/test_vectors.py
@@ -177,6 +177,8 @@ class UtilTest(TestCase):
         b[4] = False
 
         self.assertEqual(list(b), [True, True, True, True, False])
+        self.assertEqual(b.count(True), 4)
+        self.assertEqual(b.count(False), 1)
 
     def test_activeList(self):
         active_list = IntVector.active_list("1,10,100-105")
@@ -579,3 +581,15 @@ class UtilTest(TestCase):
         self.assertNotEqual(v1, v2)
         v2[3] = 99
         self.assertEqual(v1, v2)
+
+    def test_create_active_list(self):
+        vec = BoolVector(False, 10)
+        vec[0] = True
+        vec[3] = True
+        vec[7] = True
+
+        idxs = vec.createActiveList()
+        self.assertTrue(len(idxs) == 3, "Should get 3 indices")
+        self.assertEqual(idxs[0], 0)
+        self.assertEqual(idxs[1], 3)
+        self.assertEqual(idxs[2], 7)


### PR DESCRIPTION
The wrapped function bool_vector_count_equal() should not explicitly pass self since that is done implicitly. No idea why this works at all...