### PR TITLE
Fix ecl_util_get_num_cpu function

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,7 +58,7 @@ jobs:
         fetch-depth: 0
 
     - name: Build Linux Wheel
-      uses: docker://quay.io/pypa/manylinux2010_x86_64
+      uses: docker://quay.io/pypa/manylinux2010_x86_64:2022-04-03-da6ecb3
       with:
         entrypoint: /github/workspace/ci/github/build_linux_wheel.sh
         args: ${{ matrix.python }}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -375,7 +375,8 @@ add_test(
     ecl_get_num_cpu ${CMAKE_CURRENT_SOURCE_DIR}/ecl/tests/data/num_cpu1
     ${CMAKE_CURRENT_SOURCE_DIR}/ecl/tests/data/num_cpu2
     ${CMAKE_CURRENT_SOURCE_DIR}/ecl/tests/data/num_cpu3
-    ${CMAKE_CURRENT_SOURCE_DIR}/ecl/tests/data/num_cpu4)
+    ${CMAKE_CURRENT_SOURCE_DIR}/ecl/tests/data/num_cpu4
+    ${CMAKE_CURRENT_SOURCE_DIR}/ecl/tests/data/num_cpu5)
 
 # The ecl_win64 application is not built as a proper test integrated into the
 # CTEST system. Should be invoked manually on Windows.

--- a/lib/ecl/tests/data/num_cpu5
+++ b/lib/ecl/tests/data/num_cpu5
@@ -1,0 +1,18 @@
+----------------------------------------------------------------------
+-- A very simple test case for the shared memory parallel option.
+-- --------------------------------------------------------------
+
+TITLE
+foo
+
+TITLE
+PARALLEL BENCHMARK
+
+TITLE
+foo
+
+PARALLEL
+-- TITLE
+-- foo
+  4  DISTRIBUTED /
+

--- a/lib/ecl/tests/ecl_get_num_cpu_test.cpp
+++ b/lib/ecl/tests/ecl_get_num_cpu_test.cpp
@@ -26,10 +26,12 @@ int main(int argc, char **argv) {
     const char *filename2 = argv[2];
     const char *filename3 = argv[3];
     const char *filename4 = argv[4];
+    const char *filename5 = argv[5];
 
     test_assert_int_equal(ecl_util_get_num_cpu(filename1), 4);
     test_assert_int_equal(ecl_util_get_num_cpu(filename2), 4);
     test_assert_int_equal(ecl_util_get_num_cpu(filename3), 15);
     test_assert_int_equal(ecl_util_get_num_cpu(filename4), 4);
+    test_assert_int_equal(ecl_util_get_num_cpu(filename5), 4);
     exit(0);
 }


### PR DESCRIPTION
**Issue**
The `ecl_util_get_num_cpu` function is used by ERT to parse the `PARALLEL` keyword. This fails if the `PARALLEL` word appears in the `TITLE` keyword value. The result is that ERT detects the number of cpus as equal to one in such a case.

This PR is required to be able to resolve this `ERT` issue: https://github.com/equinor/ert/issues/1905

**Approach**
While scanning the file for `PARALLEL` keywords, detect if they occur in a title and so, skip them.

**Note**
This PR also pins manylinux2014, since cause failure, as was done for `ERT`.