### PR TITLE
adding two missing header files

### DIFF
--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <algorithm>
 #include <memory>
+#include <stdexcept>
 
 #include <ert/util/hash.hpp>
 #include <ert/util/util.h>

--- a/lib/private-include/detail/ecl/ecl_sum_file_data.hpp
+++ b/lib/private-include/detail/ecl/ecl_sum_file_data.hpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include <memory>
 #include <array>
+#include <limits>
 
 #include <ert/util/vector.hpp>
 


### PR DESCRIPTION
**Issue**
compilation errors were reported with Ubuntu 22.04 and g++ version 11.2.0
```c++
libecl/lib/ecl/ecl_smspec.cpp:754:16: error: ‘invalid_argument’ is not a member of ‘std’
  754 |     throw std::invalid_argument("Internal error - should not be here \n");
```
```c++
libecl/lib/private-include/detail/ecl/ecl_sum_file_data.hpp:40:73: error: ‘numeric_limits’ is not a member of ‘std’
   40 |       this->report_map.resize( report_step + 1, std::pair<int,int>(std::numeric_limits<int>::max(), -1));
      |                                                                         ^~~~~~~~~~~~~~
```

**Approach**
adding header files <stdexcept> and <limits> in the problematic files.

