### PR TITLE
Add windows build to release albeit without testing.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -71,10 +71,13 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
-    - name: Build Windows Wheel
+    - name: Setup VS-devshell
       uses: egor-tensin/vs-shell@v2
       with:
         arch: x64
+      if: matrix.os == 'windows-latest'
+
+    - name: Build Windows Wheel
       run: 
         cl.exe
         pip wheel . --no-deps -w dist

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,9 +77,13 @@ jobs:
         arch: x64
       if: matrix.os == 'windows-latest'
 
-    - name: Build Windows Wheel
-      run: 
+    - name: Check CL
+      run:
         cl.exe
+      if: matrix.os == 'windows-latest'
+
+    - name: Build Windows Wheel
+      run:
         pip wheel . --no-deps -w dist
       if: matrix.os == 'windows-latest'
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,41 +3,41 @@ name: ecl testing
 on: [push, pull_request]
 
 jobs:
-  build-test-cmake:
-    name: CMake
+  # build-test-cmake:
+  #   name: CMake
 
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: ['ubuntu-latest', 'macos-latest']
 
-    runs-on: ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
 
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        # required for `git describe --tags` to work
-        fetch-depth: 0
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #     with:
+  #       # required for `git describe --tags` to work
+  #       fetch-depth: 0
 
-    - name: Install dependencies
-      run: |
-        python3 -m pip install conan
+  #   - name: Install dependencies
+  #     run: |
+  #       python3 -m pip install conan
 
 
-    - name: Build ecl
-      run: |
-        mkdir cmake-build
-        cmake -S . -B cmake-build -DBUILD_TESTS=ON -DRST_DOC=ON
-        cmake --build cmake-build
+  #   - name: Build ecl
+  #     run: |
+  #       mkdir cmake-build
+  #       cmake -S . -B cmake-build -DBUILD_TESTS=ON -DRST_DOC=ON
+  #       cmake --build cmake-build
 
-    - name: Run tests
-      run: |
-        cd cmake-build
-        export DYLD_LIBRARY_PATH=$PWD/lib
-        ctest --output-on-failure
-      env:
-        ECL_SKIP_SIGNAL: absolutely
-        ERT_SHOW_BACKTRACE: yes please!
+  #   - name: Run tests
+  #     run: |
+  #       cd cmake-build
+  #       export DYLD_LIBRARY_PATH=$PWD/lib
+  #       ctest --output-on-failure
+  #     env:
+  #       ECL_SKIP_SIGNAL: absolutely
+  #       ERT_SHOW_BACKTRACE: yes please!
 
 
   build-test-wheel:
@@ -71,12 +71,19 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
-    - name: Build macOS/Windows Wheel
-      run: |
+    - name: Build Windows Wheel
+      uses: egor-tensin/vs-shell@v2
+      with:
+        arch: x64
+      run: 
         cl.exe
-        vcvars64.bat
         pip wheel . --no-deps -w dist
-      if: matrix.os != 'ubuntu-latest'
+      if: matrix.os == 'windows-latest'
+
+    - name: Build macOS Wheel
+      run:
+        pip wheel . --no-deps -w dist
+      if: matrix.os == 'macos-latest'
 
     # - name: Upload wheel as artifact
     #   uses: actions/upload-artifact@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -48,7 +48,6 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        python: ['3.9']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -103,11 +103,11 @@ jobs:
 
     - name: Install ecl Ubuntu/Macosx
       run: pip install dist/*
-      if: matrix.os != "windows-latest"
+      if: matrix.os != 'windows-latest'
 
     - name: Install ecl Windows
       run: pip install (dir dist/*)
-      if: matrix.os == "windows-latest"
+      if: matrix.os == 'windows-latest'
 
     - name: Run Python tests
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,26 +77,16 @@ jobs:
         arch: x64
       if: matrix.os == 'windows-latest'
 
-    - name: Check CL
-      run:
-        cl.exe
-      if: matrix.os == 'windows-latest'
-
-    - name: Build Windows Wheel
+    - name: Build macOS/Windows Wheel
       run:
         pip wheel . --no-deps -w dist
-      if: matrix.os == 'windows-latest'
+      if: matrix.os != 'ubuntu-latest'
 
-    - name: Build macOS Wheel
-      run:
-        pip wheel . --no-deps -w dist
-      if: matrix.os == 'macos-latest'
-
-    # - name: Upload wheel as artifact
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: ${{ matrix.os }} Python ${{ matrix.python }} wheel
-    #     path: dist/*
+    - name: Upload wheel as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.os }} Python ${{ matrix.python }} wheel
+        path: dist/*
 
     - name: Build `libecl` migration package
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,41 +3,41 @@ name: ecl testing
 on: [push, pull_request]
 
 jobs:
-  # build-test-cmake:
-  #   name: CMake
+  build-test-cmake:
+    name: CMake
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ['ubuntu-latest', 'macos-latest']
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest']
 
-  #   runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #     with:
-  #       # required for `git describe --tags` to work
-  #       fetch-depth: 0
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # required for `git describe --tags` to work
+        fetch-depth: 0
 
-  #   - name: Install dependencies
-  #     run: |
-  #       python3 -m pip install conan
+    - name: Install dependencies
+      run: |
+        python3 -m pip install conan
 
 
-  #   - name: Build ecl
-  #     run: |
-  #       mkdir cmake-build
-  #       cmake -S . -B cmake-build -DBUILD_TESTS=ON -DRST_DOC=ON
-  #       cmake --build cmake-build
+    - name: Build ecl
+      run: |
+        mkdir cmake-build
+        cmake -S . -B cmake-build -DBUILD_TESTS=ON -DRST_DOC=ON
+        cmake --build cmake-build
 
-  #   - name: Run tests
-  #     run: |
-  #       cd cmake-build
-  #       export DYLD_LIBRARY_PATH=$PWD/lib
-  #       ctest --output-on-failure
-  #     env:
-  #       ECL_SKIP_SIGNAL: absolutely
-  #       ERT_SHOW_BACKTRACE: yes please!
+    - name: Run tests
+      run: |
+        cd cmake-build
+        export DYLD_LIBRARY_PATH=$PWD/lib
+        ctest --output-on-failure
+      env:
+        ECL_SKIP_SIGNAL: absolutely
+        ERT_SHOW_BACKTRACE: yes please!
 
 
   build-test-wheel:
@@ -46,9 +46,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: ['ubuntu-latest', 'macos-latest']
-        # python: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        os: ['windows-latest']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
         python: ['3.9']
 
     runs-on: ${{ matrix.os }}
@@ -135,27 +134,27 @@ jobs:
       if: matrix.os != 'windows-latest'
 
 
-  # publish:
-  #   name: Publish to PyPI
-  #   runs-on: ubuntu-latest
-  #   needs: [build-test-wheel]
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-test-wheel]
 
-  #   # If this is a tagged release
-  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    # If this is a tagged release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
-  #   steps:
-  #     - name: Get wheels
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: artifacts
+    steps:
+      - name: Get wheels
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
 
-  #     - name: Move to dist/
-  #       run: |
-  #         mkdir dist
-  #         find artifacts -name "*.whl" -exec mv '{}' dist/ \;
+      - name: Move to dist/
+        run: |
+          mkdir dist
+          find artifacts -name "*.whl" -exec mv '{}' dist/ \;
 
-  #     - name: Publish to PyPI
-  #       uses: pypa/gh-action-pypi-publish@v1.3.1
-  #       with:
-  #         user: statoil-travis
-  #         password: ${{ secrets.pypi_password }}
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.3.1
+        with:
+          user: statoil-travis
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,8 +46,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        # os: ['ubuntu-latest', 'macos-latest']
+        # python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        os: ['windows-latest']
+        python: ['3.9']
 
     runs-on: ${{ matrix.os }}
 
@@ -70,14 +72,16 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Build macOS/Windows Wheel
-      run: pip wheel . --no-deps -w dist
+      run: |
+        cl.exe
+        pip wheel . --no-deps -w dist
       if: matrix.os != 'ubuntu-latest'
 
-    - name: Upload wheel as artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ matrix.os }} Python ${{ matrix.python }} wheel
-        path: dist/*
+    # - name: Upload wheel as artifact
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: ${{ matrix.os }} Python ${{ matrix.python }} wheel
+    #     path: dist/*
 
     - name: Build `libecl` migration package
       run: |
@@ -118,29 +122,30 @@ jobs:
 
         # Run tests
         python -m pytest python/tests
+      if: matrix.os != 'windows-latest'
 
 
-  publish:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    needs: [build-test-wheel]
+  # publish:
+  #   name: Publish to PyPI
+  #   runs-on: ubuntu-latest
+  #   needs: [build-test-wheel]
 
-    # If this is a tagged release
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+  #   # If this is a tagged release
+  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
-    steps:
-      - name: Get wheels
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
+  #   steps:
+  #     - name: Get wheels
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: artifacts
 
-      - name: Move to dist/
-        run: |
-          mkdir dist
-          find artifacts -name "*.whl" -exec mv '{}' dist/ \;
+  #     - name: Move to dist/
+  #       run: |
+  #         mkdir dist
+  #         find artifacts -name "*.whl" -exec mv '{}' dist/ \;
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
-        with:
-          user: statoil-travis
-          password: ${{ secrets.pypi_password }}
+  #     - name: Publish to PyPI
+  #       uses: pypa/gh-action-pypi-publish@v1.3.1
+  #       with:
+  #         user: statoil-travis
+  #         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -101,8 +101,13 @@ jobs:
         path: dist-migration/*
       if: matrix.os == 'ubuntu-latest' && matrix.python == '3.6'
 
-    - name: Install ecl
+    - name: Install ecl Ubuntu/Macosx
       run: pip install dist/*
+      if: matrix.os != "windows-latest"
+
+    - name: Install ecl Windows
+      run: pip install (dir dist/*)
+      if: matrix.os == "windows-latest"
 
     - name: Run Python tests
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -74,6 +74,7 @@ jobs:
     - name: Build macOS/Windows Wheel
       run: |
         cl.exe
+        vcvars64.bat
         pip wheel . --no-deps -w dist
       if: matrix.os != 'ubuntu-latest'
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ __ecl_lib_info.py
 /_skbuild/
 /python/ecl/version.py
 .*
+!.github
 *.egg-info/
 
 /dist


### PR DESCRIPTION
**Issue**
Resolves #726 

**Approach**

Include windows MSVC build environment in github workflow but exclude windows from testing due to an error in the creation  of temporary memory.

I'm currently building these as unofficial artifacts for windows but if you feel they could be included in the main trunk then I make this pull request available.
