### PR TITLE
build: add support for Python 3.11

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 
@@ -58,7 +58,7 @@ jobs:
         fetch-depth: 0
 
     - name: Build Linux Wheel
-      uses: docker://quay.io/pypa/manylinux2010_x86_64
+      uses: docker://quay.io/pypa/manylinux2014_x86_64
       with:
         entrypoint: /github/workspace/ci/github/build_linux_wheel.sh
         args: ${{ matrix.python }}

--- a/ci/github/build_linux_wheel.sh
+++ b/ci/github/build_linux_wheel.sh
@@ -7,6 +7,7 @@ case "$1" in
     3.8) pyver=cp38-cp38 ;;
     3.9) pyver=cp39-cp39 ;;
     3.10) pyver=cp310-cp310 ;;
+    3.11) pyver=cp311-cp311 ;;
     *)
         echo "Unknown Python version $1"
         exit 1

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ skbuild.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
**Issue**
Resolves #879 

**Approach**
Adding Python 3.11 support by updating GitHub pipeline and setup.py. Had to bump manylinux from 2010 to 2014 in order to support Python 3.11.
