### PR TITLE
Remove copyright notices in .py, .cpp and .hpp files

### DIFF
--- a/applications/ecl/kw_extract.cpp
+++ b/applications/ecl/kw_extract.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'kw_extract.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>

--- a/applications/ecl/sum_write.cpp
+++ b/applications/ecl/sum_write.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-   The file 'sum_write' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/applications/ecl/view_summary.cpp
+++ b/applications/ecl/view_summary.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-   The file 'view_summary.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>

--- a/lib/ecl/EclFilename.cpp
+++ b/lib/ecl/EclFilename.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <string>
 #include <stdexcept>
 

--- a/lib/ecl/FortIO.cpp
+++ b/lib/ecl/FortIO.cpp
@@ -1,22 +1,3 @@
-/*
-  Copyright 2015 Equinor ASA.
-
-  This file is part of the Open Porous Media project (OPM).
-
-  OPM is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  OPM is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
 #include <stdexcept>
 
 #include <ert/util/util.h>

--- a/lib/ecl/ecl_box.cpp
+++ b/lib/ecl/ecl_box.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_box.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/lib/ecl/ecl_coarse_cell.cpp
+++ b/lib/ecl/ecl_coarse_cell.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (c) 2012  equinor asa, norway.
-
-   The file 'ecl_coarse_cell.c' is part of ert - ensemble based reservoir tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the gnu general public license as published by
-   the free software foundation, either version 3 of the license, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but without any
-   warranty; without even the implied warranty of merchantability or
-   fitness for a particular purpose.
-
-   See the gnu general public license at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/ecl/ecl_file.cpp
+++ b/lib/ecl/ecl_file.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_file.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdio.h>
 #include <string.h>
 #include <math.h>

--- a/lib/ecl/ecl_file_kw.cpp
+++ b/lib/ecl/ecl_file_kw.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_file_kw.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/lib/ecl/ecl_file_view.cpp
+++ b/lib/ecl/ecl_file_view.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   The file 'ecl_file_view.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <vector>
 #include <string>
 #include <map>

--- a/lib/ecl/ecl_grav.cpp
+++ b/lib/ecl/ecl_grav.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <math.h>
 #include <stdbool.h>

--- a/lib/ecl/ecl_grav_calc.cpp
+++ b/lib/ecl/ecl_grav_calc.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_grav.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <math.h>
 #include <stdbool.h>

--- a/lib/ecl/ecl_grav_common.cpp
+++ b/lib/ecl/ecl_grav_common.cpp
@@ -1,22 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_grav_common.c' is part of ERT - Ensemble based
-   Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>

--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (c) 2011  equinor asa, norway.
-
-   The file 'ecl_grid.c' is part of ert - ensemble based reservoir tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the gnu general public license as published by
-   the free software foundation, either version 3 of the license, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but without any
-   warranty; without even the implied warranty of merchantability or
-   fitness for a particular purpose.
-
-   See the gnu general public license at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <cstdint>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/ecl/ecl_grid_cache.cpp
+++ b/lib/ecl/ecl_grid_cache.cpp
@@ -1,22 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_grid_cache.c' is part of ERT - Ensemble based
-   Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <math.h>
 #include <stdbool.h>

--- a/lib/ecl/ecl_grid_dims.cpp
+++ b/lib/ecl/ecl_grid_dims.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_grid_dims.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/ecl_init_file.cpp
+++ b/lib/ecl/ecl_init_file.cpp
@@ -1,22 +1,4 @@
 /*
-   Copyright (C) 2012 Equinor ASA, Norway.
-
-   The file 'ecl_init_file.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
-/*
   This file contains functionality to write an ECLIPSE INIT file. The
   file does (currently) not contain any datastructures, only
   functions. Essentially this file is only a codifying of the ECLIPSE

--- a/lib/ecl/ecl_io_config.cpp
+++ b/lib/ecl/ecl_io_config.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_io_config.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/lib/ecl/ecl_kw.cpp
+++ b/lib/ecl/ecl_kw.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_kw.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/lib/ecl/ecl_kw_grdecl.cpp
+++ b/lib/ecl/ecl_kw_grdecl.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_kw_grdecl.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <string.h>
 #include <ctype.h>
 

--- a/lib/ecl/ecl_nnc_data.cpp
+++ b/lib/ecl/ecl_nnc_data.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_file_view.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #define ECL_NNC_DATA_TYPE_ID 83756236
 
 #include <ert/ecl/ecl_nnc_data.hpp>

--- a/lib/ecl/ecl_nnc_export.cpp
+++ b/lib/ecl/ecl_nnc_export.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_export.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more detals.
-*/
 #include <stdlib.h>
 
 #include <vector>

--- a/lib/ecl/ecl_nnc_geometry.cpp
+++ b/lib/ecl/ecl_nnc_geometry.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (c) 2017  equinor asa, norway.
-
-   The file 'ecl_nnc_geometry.c' is part of ert - ensemble based reservoir tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the gnu general public license as published by
-   the free software foundation, either version 3 of the license, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but without any
-   warranty; without even the implied warranty of merchantability or
-   fitness for a particular purpose.
-
-   See the gnu general public license at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <vector>
 #include <algorithm>
 

--- a/lib/ecl/ecl_region.cpp
+++ b/lib/ecl/ecl_region.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_region.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>

--- a/lib/ecl/ecl_rft_cell.cpp
+++ b/lib/ecl/ecl_rft_cell.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_rft_cell.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <math.h>
 #include <time.h>
 #include <string.h>

--- a/lib/ecl/ecl_rft_file.cpp
+++ b/lib/ecl/ecl_rft_file.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_rft_file.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/lib/ecl/ecl_rft_node.cpp
+++ b/lib/ecl/ecl_rft_node.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_rft_node.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <math.h>
 #include <time.h>
 #include <string.h>

--- a/lib/ecl/ecl_rst_file.cpp
+++ b/lib/ecl/ecl_rst_file.cpp
@@ -1,22 +1,4 @@
 
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_rst_file.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdio.h>
 #include <string.h>
 #include <math.h>

--- a/lib/ecl/ecl_rsthead.cpp
+++ b/lib/ecl/ecl_rsthead.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_rsthead.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 
 #include <ert/util/util.h>

--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_smspec.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <string.h>
 #include <stdbool.h>
 #include <math.h>

--- a/lib/ecl/ecl_subsidence.cpp
+++ b/lib/ecl/ecl_subsidence.cpp
@@ -1,22 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_subsidence.c' is part of ERT - Ensemble based
-   Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #define _USE_MATH_DEFINES // for C WINDOWS
 #include <math.h>

--- a/lib/ecl/ecl_sum.cpp
+++ b/lib/ecl/ecl_sum.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_sum.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdexcept>
 
 #include <string.h>

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_sum_data.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <string.h>
 #include <math.h>
 

--- a/lib/ecl/ecl_sum_index.cpp
+++ b/lib/ecl/ecl_sum_index.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_sum_index.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ert/ecl/ecl_sum_index.hpp>
 
 /*

--- a/lib/ecl/ecl_sum_tstep.cpp
+++ b/lib/ecl/ecl_sum_tstep.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_sum_tstep.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <time.h>
 #include <math.h>
 

--- a/lib/ecl/ecl_sum_vector.cpp
+++ b/lib/ecl/ecl_sum_vector.cpp
@@ -1,20 +1,3 @@
-/*
-  Copyright (C) 2014  Equinor ASA, Norway.
-
-  The file 'ecl_sum_vector.c' is part of ERT - Ensemble based Reservoir Tool.
-
-  ERT is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.
-
-  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-  for more details.
-*/
 #include <stdlib.h>
 
 #include <vector>

--- a/lib/ecl/ecl_type.cpp
+++ b/lib/ecl/ecl_type.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_type.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>

--- a/lib/ecl/ecl_util.cpp
+++ b/lib/ecl/ecl_util.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_util.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/lib/ecl/fault_block.cpp
+++ b/lib/ecl/fault_block.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'fault_block.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <vector>
 
 #include <ert/util/type_macros.hpp>

--- a/lib/ecl/fault_block_layer.cpp
+++ b/lib/ecl/fault_block_layer.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'fault_block_layer.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ert/util/type_macros.hpp>
 #include <ert/util/int_vector.hpp>
 #include <ert/util/double_vector.hpp>

--- a/lib/ecl/grid_dims.cpp
+++ b/lib/ecl/grid_dims.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'grid_dims.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 
 #include <ert/util/util.h>

--- a/lib/ecl/layer.cpp
+++ b/lib/ecl/layer.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'layer.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <math.h>
 

--- a/lib/ecl/nnc_info.cpp
+++ b/lib/ecl/nnc_info.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'nnc_info.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 
 #include <vector>

--- a/lib/ecl/nnc_vector.cpp
+++ b/lib/ecl/nnc_vector.cpp
@@ -1,22 +1,4 @@
 
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'nnc_vector.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 
 #include <vector>

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'smspec_node.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <string.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/lib/ecl/tests/ecl_coarse_test.cpp
+++ b/lib/ecl/tests/ecl_coarse_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_coarse_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_dualp.cpp
+++ b/lib/ecl/tests/ecl_dualp.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_dualp.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_fault_block_collection_equinor.cpp
+++ b/lib/ecl/tests/ecl_fault_block_collection_equinor.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_fault_block_collection_equinor.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/ecl_fault_block_layer.cpp
+++ b/lib/ecl/tests/ecl_fault_block_layer.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_fault_block_layer.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/ecl_fault_block_layer_equinor.cpp
+++ b/lib/ecl/tests/ecl_fault_block_layer_equinor.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_fault_block_layer_equinor.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/ecl_file.cpp
+++ b/lib/ecl/tests/ecl_file.cpp
@@ -1,21 +1,4 @@
 
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_file.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/ecl_file_equinor.cpp
+++ b/lib/ecl/tests/ecl_file_equinor.cpp
@@ -1,21 +1,4 @@
 
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_file_equinor.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/ecl_file_view.cpp
+++ b/lib/ecl/tests/ecl_file_view.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_file_view.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/ecl_fmt.cpp
+++ b/lib/ecl/tests/ecl_fmt.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_fmt.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/ecl_fortio.cpp
+++ b/lib/ecl/tests/ecl_fortio.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_fortio.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_get_num_cpu_test.cpp
+++ b/lib/ecl/tests/ecl_get_num_cpu_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_get_num_cpu_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_add_nnc.cpp
+++ b/lib/ecl/tests/ecl_grid_add_nnc.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   The file 'ecl_grid_add_nnc.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_cell_contains.cpp
+++ b/lib/ecl/tests/ecl_grid_cell_contains.cpp
@@ -1,22 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_grid_cell_contains.c' is part of ERT - Ensemble based
-   Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>

--- a/lib/ecl/tests/ecl_grid_cell_contains_wellpath.cpp
+++ b/lib/ecl/tests/ecl_grid_cell_contains_wellpath.cpp
@@ -1,22 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_grid_cell_contains_wellpath.c' is part of ERT -
-   Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>

--- a/lib/ecl/tests/ecl_grid_copy.cpp
+++ b/lib/ecl/tests/ecl_grid_copy.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_grid_copy.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_corner.cpp
+++ b/lib/ecl/tests/ecl_grid_corner.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_grid_corner.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_create.cpp
+++ b/lib/ecl/tests/ecl_grid_create.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_grid_create.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <signal.h>

--- a/lib/ecl/tests/ecl_grid_dims.cpp
+++ b/lib/ecl/tests/ecl_grid_dims.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_grid_dims.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <signal.h>

--- a/lib/ecl/tests/ecl_grid_dx_dy_dz.cpp
+++ b/lib/ecl/tests/ecl_grid_dx_dy_dz.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_grid_dims.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <signal.h>

--- a/lib/ecl/tests/ecl_grid_export.cpp
+++ b/lib/ecl/tests/ecl_grid_export.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_grid_export.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_init_fwrite.cpp
+++ b/lib/ecl/tests/ecl_grid_init_fwrite.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_layer_contains.cpp
+++ b/lib/ecl/tests/ecl_grid_layer_contains.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_grid_layer_contains' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_lgr_name.cpp
+++ b/lib/ecl/tests/ecl_grid_lgr_name.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_grid_lgr_name.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_reset_actnum.cpp
+++ b/lib/ecl/tests/ecl_grid_reset_actnum.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_grid_reset_actnum.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_unit_system.cpp
+++ b/lib/ecl/tests/ecl_grid_unit_system.cpp
@@ -1,20 +1,3 @@
-/*
-  Copyright (C) 2018  Equinor ASA, Norway.
-
-  The file 'ecl_grid_unit_system.c' is part of ERT - Ensemble based Reservoir Tool.
-
-  ERT is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.
-
-  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-  for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_grid_volume.cpp
+++ b/lib/ecl/tests/ecl_grid_volume.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_grid_volume.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <signal.h>

--- a/lib/ecl/tests/ecl_init_file.cpp
+++ b/lib/ecl/tests/ecl_init_file.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   The file 'ecl_init_file.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_kw_cmp_string.cpp
+++ b/lib/ecl/tests/ecl_kw_cmp_string.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_kw_cmp_string.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_kw_equal.cpp
+++ b/lib/ecl/tests/ecl_kw_equal.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_kw_equal.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_kw_fread.cpp
+++ b/lib/ecl/tests/ecl_kw_fread.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2015  Equinor ASA, Norway.
-
-   The file 'ecl_kw_init.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_kw_grdecl.cpp
+++ b/lib/ecl/tests/ecl_kw_grdecl.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_kw_grdecl.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_kw_init.cpp
+++ b/lib/ecl/tests/ecl_kw_init.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_kw_init.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_kw_space_pad.cpp
+++ b/lib/ecl/tests/ecl_kw_space_pad.cpp
@@ -1,20 +1,3 @@
-/*
-  Copyright (C) 2019  Equinor ASA, Norway.
-
-  The file 'ecl_grid_unit_system.c' is part of ERT - Ensemble based Reservoir Tool.
-
-  ERT is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.
-
-  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-  for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_layer.cpp
+++ b/lib/ecl/tests/ecl_layer.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_layer.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_layer_equinor.cpp
+++ b/lib/ecl/tests/ecl_layer_equinor.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ecl_layer_equinor.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_lfs.cpp
+++ b/lib/ecl/tests/ecl_lfs.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_win64.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_lgr_name.cpp
+++ b/lib/ecl/tests/ecl_lgr_name.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_lgr_name.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_lgr_test.cpp
+++ b/lib/ecl/tests/ecl_lgr_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_lgr_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_nnc_data_equinor_root.cpp
+++ b/lib/ecl/tests/ecl_nnc_data_equinor_root.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'test_ecl_nnc_data_equinor.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ert/ecl/ecl_nnc_data.hpp>
 #include <ert/ecl/ecl_kw_magic.hpp>
 #include <ert/ecl/ecl_nnc_geometry.hpp>

--- a/lib/ecl/tests/ecl_nnc_export.cpp
+++ b/lib/ecl/tests/ecl_nnc_export.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_export.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more detals.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <signal.h>

--- a/lib/ecl/tests/ecl_nnc_export_get_tran.cpp
+++ b/lib/ecl/tests/ecl_nnc_export_get_tran.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_export.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-    ll
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_nnc_export_intersect.cpp
+++ b/lib/ecl/tests/ecl_nnc_export_intersect.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2018  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_export_intersect.c' is part of ERT - Ensemble based
-   Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more detals.
-*/
 // #include <stdlib.h>
 // #include <stdbool.h>
 #include <signal.h>

--- a/lib/ecl/tests/ecl_nnc_geometry.cpp
+++ b/lib/ecl/tests/ecl_nnc_geometry.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_geometry.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <ert/util/test_util.hpp>
 #include <ert/util/test_work_area.hpp>
 

--- a/lib/ecl/tests/ecl_nnc_index_list.cpp
+++ b/lib/ecl/tests/ecl_nnc_index_list.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_index_list.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_nnc_index_list_grid.cpp
+++ b/lib/ecl/tests/ecl_nnc_index_list_grid.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_index_list_grid.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_nnc_info_test.cpp
+++ b/lib/ecl/tests/ecl_nnc_info_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_info_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_nnc_pair.cpp
+++ b/lib/ecl/tests/ecl_nnc_pair.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_pair.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_nnc_test.cpp
+++ b/lib/ecl/tests/ecl_nnc_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_nnc_vector.cpp
+++ b/lib/ecl/tests/ecl_nnc_vector.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_vector.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_region.cpp
+++ b/lib/ecl/tests/ecl_region.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_region.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_region2region.cpp
+++ b/lib/ecl/tests/ecl_region2region.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_region2region.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_restart_test.cpp
+++ b/lib/ecl/tests/ecl_restart_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_restart_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_rft.cpp
+++ b/lib/ecl/tests/ecl_rft.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_rft.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_rft_cell.cpp
+++ b/lib/ecl/tests/ecl_rft_cell.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_rft_cell.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_rst_file.cpp
+++ b/lib/ecl/tests/ecl_rst_file.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   The file 'ecl_rst_file.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_rsthead.cpp
+++ b/lib/ecl/tests/ecl_rsthead.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_rst_header.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_smspec.cpp
+++ b/lib/ecl/tests/ecl_smspec.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_smspec_node.cpp
+++ b/lib/ecl/tests/ecl_smspec_node.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_sum_case_exists.cpp
+++ b/lib/ecl/tests/ecl_sum_case_exists.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_sum_case_exists.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/ecl_sum_report_step_compatible.cpp
+++ b/lib/ecl/tests/ecl_sum_report_step_compatible.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_sum_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_sum_report_step_equal.cpp
+++ b/lib/ecl/tests/ecl_sum_report_step_equal.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_sum_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_sum_test.cpp
+++ b/lib/ecl/tests/ecl_sum_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_sum_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_sum_writer.cpp
+++ b/lib/ecl/tests/ecl_sum_writer.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   The file 'ecl_sum_writer.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdexcept>

--- a/lib/ecl/tests/ecl_util_filenames.cpp
+++ b/lib/ecl/tests/ecl_util_filenames.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2018  Equinor ASA, Norway.
-
-   The file 'ecl_util_filenames.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_util_make_date_no_shift.cpp
+++ b/lib/ecl/tests/ecl_util_make_date_no_shift.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_util_make_date_no_shift.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_util_make_date_shift.cpp
+++ b/lib/ecl/tests/ecl_util_make_date_shift.cpp
@@ -1,19 +1,3 @@
-/*  Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_util_make_date_shift.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_util_month_range.cpp
+++ b/lib/ecl/tests/ecl_util_month_range.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_util_month_range.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/ecl_util_path_access.cpp
+++ b/lib/ecl/tests/ecl_util_path_access.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2018  Equinor ASA, Norway.
-
-   The file 'ecl_util_path_access.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/ecl_valid_basename.cpp
+++ b/lib/ecl/tests/ecl_valid_basename.cpp
@@ -1,27 +1,3 @@
-/*
-
- *
- *  Created on: Sep 2, 2013
- *      Author: joaho
- */
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_lgr_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ert/util/test_util.hpp>
 #include <ert/ecl/ecl_util.hpp>
 

--- a/lib/ecl/tests/eclxx_filename.cpp
+++ b/lib/ecl/tests/eclxx_filename.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ert/util/test_util.hpp>
 #include <ert/ecl/EclFilename.hpp>
 

--- a/lib/ecl/tests/eclxx_fortio.cpp
+++ b/lib/ecl/tests/eclxx_fortio.cpp
@@ -1,22 +1,3 @@
-/*
-  Copyright 2015 Equinor ASA.
-
-  This file is part of the Open Porous Media project (OPM).
-
-  OPM is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  OPM is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
 #include <stdexcept>
 #include <fstream>
 

--- a/lib/ecl/tests/eclxx_kw.cpp
+++ b/lib/ecl/tests/eclxx_kw.cpp
@@ -1,22 +1,3 @@
-/*
-  Copyright 2015 Equinor ASA.
-
-  This file is part of the Open Porous Media project (OPM).
-
-  OPM is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  OPM is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
 #include <stdexcept>
 #include <fstream>
 

--- a/lib/ecl/tests/eclxx_types.cpp
+++ b/lib/ecl/tests/eclxx_types.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdexcept>
 #include <fstream>
 

--- a/lib/ecl/tests/rft_test.cpp
+++ b/lib/ecl/tests/rft_test.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'rft_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ecl_rft_file.h>
 #include <ecl_rft_node.h>
 #include <stringlist.h>

--- a/lib/ecl/tests/test_ecl_file_index.cpp
+++ b/lib/ecl/tests/test_ecl_file_index.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'test_ecl_file_index.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdio.h>
 #include <utime.h>
 

--- a/lib/ecl/tests/test_ecl_nnc_data.cpp
+++ b/lib/ecl/tests/test_ecl_nnc_data.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'test_ecl_nnc_data.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ert/ecl/ecl_nnc_data.hpp>
 #include <ert/ecl/ecl_kw_magic.hpp>
 #include <ert/ecl/ecl_nnc_geometry.hpp>

--- a/lib/ecl/tests/test_transactions.cpp
+++ b/lib/ecl/tests/test_transactions.cpp
@@ -1,21 +1,4 @@
 
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'test_transactions.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/well_branch_collection.cpp
+++ b/lib/ecl/tests/well_branch_collection.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_branch_collection.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_conn.cpp
+++ b/lib/ecl/tests/well_conn.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_conn.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_conn_CF.cpp
+++ b/lib/ecl/tests/well_conn_CF.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_conn_load.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_conn_collection.cpp
+++ b/lib/ecl/tests/well_conn_collection.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_conn_collection.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_conn_load.cpp
+++ b/lib/ecl/tests/well_conn_load.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_conn_load.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_dualp.cpp
+++ b/lib/ecl/tests/well_dualp.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_dualp.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_info.cpp
+++ b/lib/ecl/tests/well_info.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_conn.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_lgr_load.cpp
+++ b/lib/ecl/tests/well_lgr_load.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_lgr_load.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <time.h>
 #include <stdbool.h>
 #include <signal.h>

--- a/lib/ecl/tests/well_segment.cpp
+++ b/lib/ecl/tests/well_segment.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_segment.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_segment_branch_conn_load.cpp
+++ b/lib/ecl/tests/well_segment_branch_conn_load.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_segment_conn_load.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/well_segment_collection.cpp
+++ b/lib/ecl/tests/well_segment_collection.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_segment_collection.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_segment_conn.cpp
+++ b/lib/ecl/tests/well_segment_conn.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_segment_conn.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_segment_conn_load.cpp
+++ b/lib/ecl/tests/well_segment_conn_load.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_segment_conn_load.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/ecl/tests/well_segment_load.cpp
+++ b/lib/ecl/tests/well_segment_load.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_segment_load.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_state.cpp
+++ b/lib/ecl/tests/well_state.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_state.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_state_load.cpp
+++ b/lib/ecl/tests/well_state_load.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_state_load.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_state_load_missing_RSEG.cpp
+++ b/lib/ecl/tests/well_state_load_missing_RSEG.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_state_load_missing_RSEG.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/tests/well_ts.cpp
+++ b/lib/ecl/tests/well_ts.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_ts.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/ecl/well_branch_collection.cpp
+++ b/lib/ecl/well_branch_collection.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_branch_collection.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 
 #include <vector>

--- a/lib/ecl/well_conn.cpp
+++ b/lib/ecl/well_conn.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_conn.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 #include <string.h>
 

--- a/lib/ecl/well_conn_collection.cpp
+++ b/lib/ecl/well_conn_collection.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_conn_collection.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 
 #include <vector>

--- a/lib/ecl/well_info.cpp
+++ b/lib/ecl/well_info.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_info.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <time.h>
 #include <stdbool.h>
 

--- a/lib/ecl/well_rseg_loader.cpp
+++ b/lib/ecl/well_rseg_loader.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_info.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 
 #include <ert/util/util.h>

--- a/lib/ecl/well_segment.cpp
+++ b/lib/ecl/well_segment.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_segment.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 
 #include <map>

--- a/lib/ecl/well_segment_collection.cpp
+++ b/lib/ecl/well_segment_collection.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_segment_collection.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 
 #include <vector>

--- a/lib/ecl/well_state.cpp
+++ b/lib/ecl/well_state.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_state.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 /**
    The well_state_type structure contains state information about one
    well for one particular point in time.

--- a/lib/ecl/well_ts.cpp
+++ b/lib/ecl/well_ts.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_ts.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 /**
    The wells can typically change configuration during a simulation,
    new completions can be added, the well can be shut for a period, it

--- a/lib/geometry/geo_pointset.cpp
+++ b/lib/geometry/geo_pointset.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_pointset.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <math.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/lib/geometry/geo_polygon.cpp
+++ b/lib/geometry/geo_polygon.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_polygon.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>

--- a/lib/geometry/geo_polygon_collection.cpp
+++ b/lib/geometry/geo_polygon_collection.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'geo_polygon_collection.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/geometry/geo_region.cpp
+++ b/lib/geometry/geo_region.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_region.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/geometry/geo_surface.cpp
+++ b/lib/geometry/geo_surface.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_surface.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <math.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/lib/geometry/geo_util.cpp
+++ b/lib/geometry/geo_util.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_util.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>

--- a/lib/geometry/tests/geo_polygon.cpp
+++ b/lib/geometry/tests/geo_polygon.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'geo_surface.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/lib/geometry/tests/geo_polygon_collection.cpp
+++ b/lib/geometry/tests/geo_polygon_collection.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'geo_polygon_collection.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/lib/geometry/tests/geo_surface.cpp
+++ b/lib/geometry/tests/geo_surface.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'geo_surface.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/lib/geometry/tests/geo_util_xlines.cpp
+++ b/lib/geometry/tests/geo_util_xlines.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'geo_util_xlines.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/lib/include/ert/ecl/EclFilename.hpp
+++ b/lib/include/ert/ecl/EclFilename.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_FILEMAME_HPP
 #define ERT_ECL_FILEMAME_HPP
 #include <string>

--- a/lib/include/ert/ecl/EclKW.hpp
+++ b/lib/include/ert/ecl/EclKW.hpp
@@ -1,22 +1,3 @@
-/*
-  Copyright 2015 Equinor ASA.
-
-  This file is part of the Open Porous Media project (OPM).
-
-  OPM is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  OPM is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
 #ifndef OPM_ERT_ECL_KW
 #define OPM_ERT_ECL_KW
 

--- a/lib/include/ert/ecl/FortIO.hpp
+++ b/lib/include/ert/ecl/FortIO.hpp
@@ -1,22 +1,3 @@
-/*
-  Copyright 2015 Equinor ASA.
-
-  This file is part of the Open Porous Media project (OPM).
-
-  OPM is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  OPM is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
 #ifndef OPM_ERT_FORTIO_KW
 #define OPM_ERT_FORTIO_KW
 

--- a/lib/include/ert/ecl/ecl_box.hpp
+++ b/lib/include/ert/ecl/ecl_box.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_box.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_BOX_H
 #define ERT_ECL_BOX_H
 

--- a/lib/include/ert/ecl/ecl_coarse_cell.hpp
+++ b/lib/include/ert/ecl/ecl_coarse_cell.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_COARSE_CELL_H
 #define ERT_ECL_COARSE_CELL_H
 

--- a/lib/include/ert/ecl/ecl_endian_flip.hpp
+++ b/lib/include/ert/ecl/ecl_endian_flip.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_endian_flip.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_ENDIAN_FLIP_H
 #define ERT_ECL_ENDIAN_FLIP_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_file.hpp
+++ b/lib/include/ert/ecl/ecl_file.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_file.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_FILE_H
 #define ERT_ECL_FILE_H
 

--- a/lib/include/ert/ecl/ecl_file_kw.hpp
+++ b/lib/include/ert/ecl/ecl_file_kw.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_file_kw.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_FILE_KW_H
 #define ERT_ECL_FILE_KW_H
 

--- a/lib/include/ert/ecl/ecl_file_view.hpp
+++ b/lib/include/ert/ecl/ecl_file_view.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_FILE_VIEW_H
 #define ERT_ECL_FILE_VIEW_H
 

--- a/lib/include/ert/ecl/ecl_grav.hpp
+++ b/lib/include/ert/ecl/ecl_grav.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_GRAV_H
 #define ERT_ECL_GRAV_H
 

--- a/lib/include/ert/ecl/ecl_grav_calc.hpp
+++ b/lib/include/ert/ecl/ecl_grav_calc.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_grav.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_GRAV_CALC_H
 #define ERT_ECL_GRAV_CALC_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_grav_common.hpp
+++ b/lib/include/ert/ecl/ecl_grav_common.hpp
@@ -1,22 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_grav_common.h' is part of ERT - Ensemble based
-   Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_GRAV_COMMON_H
 #define ERT_ECL_GRAV_COMMON_H
 

--- a/lib/include/ert/ecl/ecl_grid.hpp
+++ b/lib/include/ert/ecl/ecl_grid.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_grid.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_GRID_H
 #define ERT_ECL_GRID_H
 

--- a/lib/include/ert/ecl/ecl_grid_dims.hpp
+++ b/lib/include/ert/ecl/ecl_grid_dims.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_grid_dims.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_GRID_DIMS_H
 #define ERT_ECL_GRID_DIMS_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_init_file.hpp
+++ b/lib/include/ert/ecl/ecl_init_file.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012 Equinor ASA, Norway.
-
-   The file 'ecl_init_file.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_INIT_FILE_H
 #define ERT_ECL_INIT_FILE_H
 

--- a/lib/include/ert/ecl/ecl_io_config.hpp
+++ b/lib/include/ert/ecl/ecl_io_config.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_io_config.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_IO_CONFIG_H
 #define ERT_ECL_IO_CONFIG_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_kw.hpp
+++ b/lib/include/ert/ecl/ecl_kw.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_kw.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_KW_H
 #define ERT_ECL_KW_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_kw_grdecl.hpp
+++ b/lib/include/ert/ecl/ecl_kw_grdecl.hpp
@@ -1,22 +1,4 @@
 /*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_kw_grdecl.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
-/*
  This header does not define datatypes; just a couple of functions. It should
  be included from the ecl_kw.h header, so applications do not need to include this
  header explicitly.

--- a/lib/include/ert/ecl/ecl_nnc_data.hpp
+++ b/lib/include/ert/ecl/ecl_nnc_data.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_geometry.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ECL_NNC_DATA_H
 #define ECL_NNC_DATA_H
 

--- a/lib/include/ert/ecl/ecl_nnc_export.hpp
+++ b/lib/include/ert/ecl/ecl_nnc_export.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_export.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_NNC_EXPORT
 #define ERT_ECL_NNC_EXPORT
 

--- a/lib/include/ert/ecl/ecl_nnc_geometry.hpp
+++ b/lib/include/ert/ecl/ecl_nnc_geometry.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_nnc_geometry.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_NNC_GEOMETRY_H
 #define ERT_NNC_GEOMETRY_H
 

--- a/lib/include/ert/ecl/ecl_region.hpp
+++ b/lib/include/ert/ecl/ecl_region.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_region.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_REGION_H
 #define ERT_ECL_REGION_H
 #include <stdbool.h>

--- a/lib/include/ert/ecl/ecl_rft_cell.hpp
+++ b/lib/include/ert/ecl/ecl_rft_cell.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_rft_cell.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_RFT_CELL_H
 #define ERT_ECL_RFT_CELL_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_rft_file.hpp
+++ b/lib/include/ert/ecl/ecl_rft_file.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_rft_file.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_RFT_FILE_H
 #define ERT_ECL_RFT_FILE_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_rft_node.hpp
+++ b/lib/include/ert/ecl/ecl_rft_node.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_rft_node.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_RFT_NODE_H
 #define ERT_ECL_RFT_NODE_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_rst_file.hpp
+++ b/lib/include/ert/ecl/ecl_rst_file.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_rst_file.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_RST_FILE_H
 #define ERT_ECL_RST_FILE_H
 

--- a/lib/include/ert/ecl/ecl_rsthead.hpp
+++ b/lib/include/ert/ecl/ecl_rsthead.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_RSTHEAD.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_RSTHEAD_H
 #define ERT_ECL_RSTHEAD_H
 

--- a/lib/include/ert/ecl/ecl_smspec.hpp
+++ b/lib/include/ert/ecl/ecl_smspec.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_smspec.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_SMSPEC
 #define ERT_ECL_SMSPEC
 

--- a/lib/include/ert/ecl/ecl_subsidence.hpp
+++ b/lib/include/ert/ecl/ecl_subsidence.hpp
@@ -1,22 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_subsidence.h' is part of ERT - Ensemble based
-   Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_SUBSIDENCE_H
 #define ERT_ECL_SUBSIDENCE_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/ecl_sum.hpp
+++ b/lib/include/ert/ecl/ecl_sum.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_sum.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_SUM_H
 #define ERT_ECL_SUM_H
 

--- a/lib/include/ert/ecl/ecl_sum_data.hpp
+++ b/lib/include/ert/ecl/ecl_sum_data.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_sum_data.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_SUM_DATA_H
 #define ERT_ECL_SUM_DATA_H
 

--- a/lib/include/ert/ecl/ecl_sum_index.hpp
+++ b/lib/include/ert/ecl/ecl_sum_index.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_sum_index.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_SUM_INDEX_H
 #define ERT_ECL_SUM_INDEX_H
 

--- a/lib/include/ert/ecl/ecl_sum_tstep.hpp
+++ b/lib/include/ert/ecl/ecl_sum_tstep.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ecl_sum_tstep.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_SUM_TSTEP_H
 #define ERT_ECL_SUM_TSTEP_H
 

--- a/lib/include/ert/ecl/ecl_sum_vector.hpp
+++ b/lib/include/ert/ecl/ecl_sum_vector.hpp
@@ -1,21 +1,3 @@
-/*
-  Copyright (C) 2014  Equinor ASA, Norway.
-
-  The file 'ecl_sum_vector.h' is part of ERT - Ensemble based Reservoir Tool.
-
-  ERT is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.
-
-  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-  for more details.
-*/
-
 #ifndef ERT_ECL_SUM_VECTOR_H
 #define ERT_ECL_SUM_VECTOR_H
 

--- a/lib/include/ert/ecl/ecl_type.hpp
+++ b/lib/include/ert/ecl/ecl_type.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_type.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_TYPE_H
 #define ERT_ECL_TYPE_H
 

--- a/lib/include/ert/ecl/ecl_units.hpp
+++ b/lib/include/ert/ecl/ecl_units.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ecl_units.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ECL_UNITS_H
 #define ECL_UNITS_H
 

--- a/lib/include/ert/ecl/ecl_util.hpp
+++ b/lib/include/ert/ecl/ecl_util.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_util.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_UTIL_H
 #define ERT_ECL_UTIL_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/fault_block.hpp
+++ b/lib/include/ert/ecl/fault_block.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'fault_block.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_FAULT_BLOCK_H
 #define ERT_FAULT_BLOCK_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/fault_block_layer.hpp
+++ b/lib/include/ert/ecl/fault_block_layer.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'fault_block_layer.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_FAULT_BLOCK_LAYER_H
 #define ERT_FAULT_BLOCK_LAYER_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/grid_dims.hpp
+++ b/lib/include/ert/ecl/grid_dims.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'grid_dims.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_GRID_DIMS_H
 #define ERT_GRID_DIMS_H
 #ifdef __cplusplus

--- a/lib/include/ert/ecl/layer.hpp
+++ b/lib/include/ert/ecl/layer.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'layer.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_LAYER_H
 #define ERT_LAYER_H
 

--- a/lib/include/ert/ecl/nnc_info.hpp
+++ b/lib/include/ert/ecl/nnc_info.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'nnc_info.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_NNC_INFO_H
 #define ERT_NNC_INFO_H
 

--- a/lib/include/ert/ecl/nnc_vector.hpp
+++ b/lib/include/ert/ecl/nnc_vector.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'nnc_vector.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_NNC_VECTOR_H
 #define ERT_NNC_VECTOR_H
 

--- a/lib/include/ert/ecl/smspec_node.hpp
+++ b/lib/include/ert/ecl/smspec_node.hpp
@@ -1,21 +1,3 @@
-/*
-  Copyright (C) 2012  Equinor ASA, Norway.
-
-  The file 'smspec_node.h' is part of ERT - Ensemble based Reservoir Tool.
-
-  ERT is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.
-
-  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-  for more details.
-*/
-
 #ifndef ERT_SMSPEC_NODE_HPP
 #define ERT_SMSPEC_NODE_HPP
 

--- a/lib/include/ert/ecl_well/well_branch_collection.hpp
+++ b/lib/include/ert/ecl_well/well_branch_collection.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_branch_collection.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_BRANCH_COLLECTION_H
 #define ERT_WELL_BRANCH_COLLECTION_H
 

--- a/lib/include/ert/ecl_well/well_conn.hpp
+++ b/lib/include/ert/ecl_well/well_conn.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_conn.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_CONN_H
 #define ERT_WELL_CONN_H
 

--- a/lib/include/ert/ecl_well/well_conn_collection.hpp
+++ b/lib/include/ert/ecl_well/well_conn_collection.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_conn_collection.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_CONN_COLLECTION_H
 #define ERT_WELL_CONN_COLLECTION_H
 

--- a/lib/include/ert/ecl_well/well_const.hpp
+++ b/lib/include/ert/ecl_well/well_const.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_const.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_CONST_H
 #define ERT_WELL_CONST_H
 

--- a/lib/include/ert/ecl_well/well_info.hpp
+++ b/lib/include/ert/ecl_well/well_info.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_info.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_INFO_H
 #define ERT_WELL_INFO_H
 

--- a/lib/include/ert/ecl_well/well_rseg_loader.hpp
+++ b/lib/include/ert/ecl_well/well_rseg_loader.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_info.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_RSEG_LOADER_H
 #define ERT_WELL_RSEG_LOADER_H
 

--- a/lib/include/ert/ecl_well/well_segment.hpp
+++ b/lib/include/ert/ecl_well/well_segment.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'well_segment.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_SEGMENT_H
 #define ERT_WELL_SEGMENT_H
 

--- a/lib/include/ert/ecl_well/well_segment_collection.hpp
+++ b/lib/include/ert/ecl_well/well_segment_collection.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-                   The file 'well_segment_collection.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_SEGMENT_COLLECTION_H
 #define ERT_WELL_SEGMENT_COLLECTION_H
 

--- a/lib/include/ert/ecl_well/well_state.hpp
+++ b/lib/include/ert/ecl_well/well_state.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_state.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_STATE_H
 #define ERT_WELL_STATE_H
 

--- a/lib/include/ert/ecl_well/well_ts.hpp
+++ b/lib/include/ert/ecl_well/well_ts.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'well_ts.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_WELL_TS_H
 #define ERT_WELL_TS_H
 

--- a/lib/include/ert/geometry/geo_pointset.hpp
+++ b/lib/include/ert/geometry/geo_pointset.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_pointset.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_GEO_POINTSET_H
 #define ERT_GEO_POINTSET_H
 

--- a/lib/include/ert/geometry/geo_polygon.hpp
+++ b/lib/include/ert/geometry/geo_polygon.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_polygon.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_GEO_POLYGON_H
 #define ERT_GEO_POLYGON_H
 

--- a/lib/include/ert/geometry/geo_polygon_collection.hpp
+++ b/lib/include/ert/geometry/geo_polygon_collection.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'geo_polygon_collection.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_GEO_POLYGON_COLLECTION_H
 #define ERT_GEO_POLYGON_COLLECTION_H
 

--- a/lib/include/ert/geometry/geo_region.hpp
+++ b/lib/include/ert/geometry/geo_region.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_region.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/include/ert/geometry/geo_surface.hpp
+++ b/lib/include/ert/geometry/geo_surface.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_surface.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_GEO_SURFACE_H
 #define ERT_GEO_SURFACE_H
 

--- a/lib/include/ert/geometry/geo_util.hpp
+++ b/lib/include/ert/geometry/geo_util.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'geo_util.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_GEO_UTIL_H
 #define ERT_GEO_UTIL_H
 

--- a/lib/include/ert/util/buffer.hpp
+++ b/lib/include/ert/util/buffer.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'buffer.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_BUFFER_H
 #define ERT_BUFFER_H
 

--- a/lib/include/ert/util/ecl_version.hpp
+++ b/lib/include/ert/util/ecl_version.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   The file 'ecl_version.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ECL_VERSION
 #define ECL_VERSION
 

--- a/lib/include/ert/util/hash.hpp
+++ b/lib/include/ert/util/hash.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'hash.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_HASH_H
 #define ERT_HASH_H
 #ifdef __cplusplus

--- a/lib/include/ert/util/hash_node.hpp
+++ b/lib/include/ert/util/hash_node.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'hash_node.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_HASH_NODE_H
 #define ERT_HASH_NODE_H
 #ifdef __cplusplus

--- a/lib/include/ert/util/hash_sll.hpp
+++ b/lib/include/ert/util/hash_sll.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'hash_sll.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_HASH_SLL_H
 #define ERT_HASH_SLL_H
 #ifdef __cplusplus

--- a/lib/include/ert/util/lookup_table.hpp
+++ b/lib/include/ert/util/lookup_table.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'lookup_table.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_LOOKUP_TABLE_H
 #define ERT_LOOKUP_TABLE_H
 

--- a/lib/include/ert/util/mzran.hpp
+++ b/lib/include/ert/util/mzran.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'mzran.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_MZRAN_H
 #define ERT_MZRAN_H
 

--- a/lib/include/ert/util/node_ctype.hpp
+++ b/lib/include/ert/util/node_ctype.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'node_ctype.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_NODE_CTYPE_H
 #define ERT_NODE_CTYPE_H
 #ifdef __cplusplus

--- a/lib/include/ert/util/node_data.hpp
+++ b/lib/include/ert/util/node_data.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'node_data.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_NODE_DATA_H
 #define ERT_NODE_DATA_H
 

--- a/lib/include/ert/util/parser.hpp
+++ b/lib/include/ert/util/parser.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'parser.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_PARSER_H
 #define ERT_PARSER_H
 #include <ert/util/stringlist.hpp>

--- a/lib/include/ert/util/path_stack.hpp
+++ b/lib/include/ert/util/path_stack.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'path_stack.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_PATH_STACK_H
 #define ERT_PATH_STACK_H
 

--- a/lib/include/ert/util/perm_vector.hpp
+++ b/lib/include/ert/util/perm_vector.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   The file 'perm_vector.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef PERM_VECTOR_H
 #define PERM_VECTOR_H
 

--- a/lib/include/ert/util/rng.hpp
+++ b/lib/include/ert/util/rng.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'rng.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_RNG_H
 #define ERT_RNG_H
 

--- a/lib/include/ert/util/ssize_t.hpp
+++ b/lib/include/ert/util/ssize_t.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ssize_t.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_SSIZE_T_H
 #define ERT_SSIZE_T_H
 

--- a/lib/include/ert/util/statistics.hpp
+++ b/lib/include/ert/util/statistics.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'statistics.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_STATISTICS_H
 #define ERT_STATISTICS_H
 

--- a/lib/include/ert/util/string_util.hpp
+++ b/lib/include/ert/util/string_util.hpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'string_util.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #ifndef ERT_STRING_UTIL_H
 #define ERT_STRING_UTIL_H
 

--- a/lib/include/ert/util/stringlist.hpp
+++ b/lib/include/ert/util/stringlist.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'stringlist.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_STRINGLIST_H
 #define ERT_STRINGLIST_H
 

--- a/lib/include/ert/util/test_util.hpp
+++ b/lib/include/ert/util/test_util.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'test_util.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_TEST_UTIL_H
 #define ERT_TEST_UTIL_H
 

--- a/lib/include/ert/util/test_work_area.hpp
+++ b/lib/include/ert/util/test_work_area.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'test_work_area.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_TEST_WORK_AREA_H
 #define ERT_TEST_WORK_AREA_H
 

--- a/lib/include/ert/util/time_interval.hpp
+++ b/lib/include/ert/util/time_interval.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2018 Equinor ASA, Norway.
-
-   This is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or1
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef TIME_INTERVAL_CXX
 #define TIME_INTERVAL_CXX
 

--- a/lib/include/ert/util/type_vector_functions.hpp
+++ b/lib/include/ert/util/type_vector_functions.hpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'type_vector_functions.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #ifndef ERT_TYPE_VECTOR_FUNCTIONS_H
 #define ERT_TYPE_VECTOR_FUNCTIONS_H
 

--- a/lib/include/ert/util/util.hpp
+++ b/lib/include/ert/util/util.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2018 Equinor ASA, Norway.
-
-   This is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or1
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef UTIL_CXX
 #define UTIL_CXX
 

--- a/lib/include/ert/util/vector.hpp
+++ b/lib/include/ert/util/vector.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'vector.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_VECTOR_H
 #define ERT_VECTOR_H
 

--- a/lib/include/ert/util/vector_util.hpp
+++ b/lib/include/ert/util/vector_util.hpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2018  Equinor ASA, Norway.
-
-   The file 'vector_util.h' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdio.h>
 
 #include <vector>

--- a/lib/private-include/detail/ecl/ecl_grid_cache.hpp
+++ b/lib/private-include/detail/ecl/ecl_grid_cache.hpp
@@ -1,22 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'ecl_grid_cache.h' is part of ERT - Ensemble based
-   Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #ifndef ERT_ECL_GRID_CACHE_H
 #define ERT_ECL_GRID_CACHE_H
 

--- a/lib/util/buffer.cpp
+++ b/lib/util/buffer.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'buffer.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>

--- a/lib/util/cxx_string_util.cpp
+++ b/lib/util/cxx_string_util.cpp
@@ -1,21 +1,3 @@
-/*
-  Copyright (C) 2018  Equinor Equinor ASA, Norway.
-
-  The file 'cxx_string_util.cpp' is part of ERT - Ensemble based Reservoir Tool.
-
-  ERT is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.
-
-  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-  for more details.
-*/
-
 #include <string>
 #include <stdarg.h>
 

--- a/lib/util/hash.cpp
+++ b/lib/util/hash.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'hash.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/lib/util/hash_node.cpp
+++ b/lib/util/hash_node.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'hash_node.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/lib/util/hash_sll.cpp
+++ b/lib/util/hash_sll.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'hash_sll.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/lib/util/lookup_table.cpp
+++ b/lib/util/lookup_table.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'lookup_table.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/lib/util/mzran.cpp
+++ b/lib/util/mzran.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'mzran.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/lib/util/node_ctype.cpp
+++ b/lib/util/node_ctype.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'node_ctype.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/lib/util/node_data.cpp
+++ b/lib/util/node_data.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'node_data.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/lib/util/parser.cpp
+++ b/lib/util/parser.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'parser.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <assert.h>
 #include <string.h>
 #include <ctype.h>

--- a/lib/util/path.cpp
+++ b/lib/util/path.cpp
@@ -1,20 +1,3 @@
-/*
-  Copyright (C) 2012  Equinor ASA, Norway.
-
-  The file 'path_stack.c' is part of ERT - Ensemble based Reservoir Tool.
-
-  ERT is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.
-
-  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-  for more details.
-*/
 #include <stdlib.h>
 
 #include <string>

--- a/lib/util/path_stack.cpp
+++ b/lib/util/path_stack.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'path_stack.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>

--- a/lib/util/perm_vector.cpp
+++ b/lib/util/perm_vector.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   The file 'perm_vector.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 
 #include <ert/util/type_macros.hpp>

--- a/lib/util/rng.cpp
+++ b/lib/util/rng.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'rng.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/lib/util/statistics.cpp
+++ b/lib/util/statistics.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'statistics.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <math.h>
 #include <stdlib.h>
 

--- a/lib/util/string_util.cpp
+++ b/lib/util/string_util.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'string_util.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/util/stringlist.cpp
+++ b/lib/util/stringlist.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'stringlist.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/util/test_util.cpp
+++ b/lib/util/test_util.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'test_util.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/lib/util/test_work_area.cpp
+++ b/lib/util/test_work_area.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'test_work_area.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ert/util/ert_api_config.hpp>
 
 #ifdef ERT_HAVE_GETUID

--- a/lib/util/tests/ert_util_approx_equal.cpp
+++ b/lib/util/tests/ert_util_approx_equal.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_approx_equal.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>

--- a/lib/util/tests/ert_util_before_after.cpp
+++ b/lib/util/tests/ert_util_before_after.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_before_after.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <time.h>

--- a/lib/util/tests/ert_util_binary_split.cpp
+++ b/lib/util/tests/ert_util_binary_split.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ert_util_binary_split.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_buffer.cpp
+++ b/lib/util/tests/ert_util_buffer.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2015  Equinor ASA, Norway.
-
-   The file 'ert_util_buffer.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_chdir.cpp
+++ b/lib/util/tests/ert_util_chdir.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ert_util_chdir.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_clamp.cpp
+++ b/lib/util/tests/ert_util_clamp.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_clamp.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_copy_file.cpp
+++ b/lib/util/tests/ert_util_copy_file.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'enkf_util_copy_file.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/lib/util/tests/ert_util_cwd_test.cpp
+++ b/lib/util/tests/ert_util_cwd_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_cwd_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_datetime.cpp
+++ b/lib/util/tests/ert_util_datetime.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   This file is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <execinfo.h>

--- a/lib/util/tests/ert_util_file_readable.cpp
+++ b/lib/util/tests/ert_util_file_readable.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ert_util_file_readable.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/util/tests/ert_util_filename.cpp
+++ b/lib/util/tests/ert_util_filename.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_PATH_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>

--- a/lib/util/tests/ert_util_hash_test.cpp
+++ b/lib/util/tests/ert_util_hash_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_hash_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_mkdir_p.cpp
+++ b/lib/util/tests/ert_util_mkdir_p.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2018  Equinor ASA, Norway.
-
-   The file 'ert_util_mkdir_p.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_normal_path.cpp
+++ b/lib/util/tests/ert_util_normal_path.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'ert_util_normal_path.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_parent_path.cpp
+++ b/lib/util/tests/ert_util_parent_path.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_parent_path.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <dirent.h>
 #include <unistd.h>

--- a/lib/util/tests/ert_util_path_stack_test.cpp
+++ b/lib/util/tests/ert_util_path_stack_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_path_stack_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/lib/util/tests/ert_util_ping.cpp
+++ b/lib/util/tests/ert_util_ping.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_ping.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_realpath.cpp
+++ b/lib/util/tests/ert_util_realpath.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ert_util_realpath.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_relpath_test.cpp
+++ b/lib/util/tests/ert_util_relpath_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_relpath_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>

--- a/lib/util/tests/ert_util_rng.cpp
+++ b/lib/util/tests/ert_util_rng.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ert_util_rng.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <set>
 #include <iostream>
 #include <fstream>

--- a/lib/util/tests/ert_util_spawn.cpp
+++ b/lib/util/tests/ert_util_spawn.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2016  Equinor ASA, Norway.
-
-   The file 'ert_util_spawn.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <sys/types.h>

--- a/lib/util/tests/ert_util_split_path.cpp
+++ b/lib/util/tests/ert_util_split_path.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2018  Equinor ASA, Norway.
-
-   The file 'ert_util_split_path.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ert/util/test_util.hpp>
 
 #include "detail/util/path.hpp"

--- a/lib/util/tests/ert_util_sscan_test.cpp
+++ b/lib/util/tests/ert_util_sscan_test.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2014  Equinor ASA, Norway.
-
-   The file 'ert_util_sscan_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <float.h>
 #include <limits.h>
 #include <math.h>

--- a/lib/util/tests/ert_util_statistics.cpp
+++ b/lib/util/tests/ert_util_statistics.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ert_util_statistics.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 
 #include <ert/util/test_util.hpp>

--- a/lib/util/tests/ert_util_strcat_test.cpp
+++ b/lib/util/tests/ert_util_strcat_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_strcat_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>

--- a/lib/util/tests/ert_util_string_util.cpp
+++ b/lib/util/tests/ert_util_string_util.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_string_util.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdarg.h>

--- a/lib/util/tests/ert_util_stringlist_test.cpp
+++ b/lib/util/tests/ert_util_stringlist_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_stringlist_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>

--- a/lib/util/tests/ert_util_strstr_int_format.cpp
+++ b/lib/util/tests/ert_util_strstr_int_format.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_str_str_int_format.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_type_vector_functions.cpp
+++ b/lib/util/tests/ert_util_type_vector_functions.cpp
@@ -1,22 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ert_util_type_vector_functions.c' is part of ERT -
-   Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_type_vector_test.cpp
+++ b/lib/util/tests/ert_util_type_vector_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_type_vector_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_unique_ptr.cpp
+++ b/lib/util/tests/ert_util_unique_ptr.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2016 Equinor ASA, Norway.
-
-   This is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or1
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <ert/util/ert_unique_ptr.hpp>
 #include <ert/util/stringlist.hpp>
 

--- a/lib/util/tests/ert_util_vector_test.cpp
+++ b/lib/util/tests/ert_util_vector_test.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_vector_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/lib/util/tests/ert_util_work_area.cpp
+++ b/lib/util/tests/ert_util_work_area.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'ert_util_PATH_test.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <dirent.h>
 #include <unistd.h>

--- a/lib/util/tests/test_area.cpp
+++ b/lib/util/tests/test_area.cpp
@@ -1,20 +1,3 @@
-/*
-  Copyright (C) 2019  Equinor ASA, Norway.
-
-  The file 'test_area.cpp' is part of ERT - Ensemble based Reservoir Tool.
-
-  ERT is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.
-
-  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-  for more details.
-*/
 #include <string>
 
 #include <ert/util/test_util.hpp>

--- a/lib/util/tests/test_thread_pool.cpp
+++ b/lib/util/tests/test_thread_pool.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2015  Equinor ASA, Norway.
-
-   The file 'test_thread_pool.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdlib.h>
 #include <pthread.h>
 

--- a/lib/util/type_vector_functions.cpp
+++ b/lib/util/type_vector_functions.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2013  Equinor ASA, Norway.
-
-   The file 'ert_util_vector_function.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdbool.h>
 
 #include <ert/util/int_vector.hpp>

--- a/lib/util/util.cpp
+++ b/lib/util/util.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'util.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 /**
   This file contains a large number of utility functions for memory
   handling, string handling and file handling. Observe that all these

--- a/lib/util/util_endian.cpp
+++ b/lib/util/util_endian.cpp
@@ -1,20 +1,3 @@
-/*
-   Copyright (C) 2012  Equinor ASA, Norway.
-
-   The file 'util_endian.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
 #include <stdint.h>
 #include <stdio.h>
 

--- a/lib/util/util_unlink.cpp
+++ b/lib/util/util_unlink.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2017  Equinor ASA, Norway.
-
-   The file 'util_unlink.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include "ert/util/build_config.hpp"
 
 #include <ert/util/util.h>

--- a/lib/util/vector.cpp
+++ b/lib/util/vector.cpp
@@ -1,21 +1,3 @@
-/*
-   Copyright (C) 2011  Equinor ASA, Norway.
-
-   The file 'vector.c' is part of ERT - Ensemble based Reservoir Tool.
-
-   ERT is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-   FITNESS FOR A PARTICULAR PURPOSE.
-
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-   for more details.
-*/
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/python/ecl/__init__.py
+++ b/python/ecl/__init__.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file '__init__.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 ert - Ensemble Reservoir Tool - a package for reservoir modeling.
 

--- a/python/ecl/ecl_type.py
+++ b/python/ecl/ecl_type.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  The file 'ecl_type.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from cwrap import BaseCClass, BaseCEnum
 from ecl import EclPrototype
 

--- a/python/ecl/ecl_util.py
+++ b/python/ecl/ecl_util.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_util.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Constants from the header ecl_util.h - some stateless functions.
 

--- a/python/ecl/eclfile/__init__.py
+++ b/python/ecl/eclfile/__init__.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 """
 The eclfile package contains several classes for working directly with ECLIPSE
 files. 

--- a/python/ecl/eclfile/ecl_3d_file.py
+++ b/python/ecl/eclfile/ecl_3d_file.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl.eclfile import EclFile, Ecl3DKW
 
 

--- a/python/ecl/eclfile/ecl_3dkw.py
+++ b/python/ecl/eclfile/ecl_3dkw.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'ecl_3dkw.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl.util.util import monkey_the_camel
 from .ecl_kw import EclKW
 

--- a/python/ecl/eclfile/ecl_file.py
+++ b/python/ecl/eclfile/ecl_file.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_file.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 The ecl_file module contains functionality to load a an ECLIPSE file
 in 'restart format'. Files of 'restart format' include restart files,

--- a/python/ecl/eclfile/ecl_file_view.py
+++ b/python/ecl/eclfile/ecl_file_view.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from __future__ import absolute_import, division, print_function, unicode_literals
 from six import string_types
 from cwrap import BaseCClass

--- a/python/ecl/eclfile/ecl_init_file.py
+++ b/python/ecl/eclfile/ecl_init_file.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'ecl_init_file.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl import EclFileEnum, EclFileFlagEnum
 from ecl.eclfile import Ecl3DFile, EclFile
 

--- a/python/ecl/eclfile/ecl_kw.py
+++ b/python/ecl/eclfile/ecl_kw.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_kw.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Support for working with one keyword from ECLIPSE file.
 

--- a/python/ecl/eclfile/ecl_restart_file.py
+++ b/python/ecl/eclfile/ecl_restart_file.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'ecl_restart_file.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from cwrap import BaseCClass
 from ecl import EclFileEnum, EclFileFlagEnum, EclPrototype
 from ecl.eclfile import Ecl3DFile, EclFile

--- a/python/ecl/eclfile/fortio.py
+++ b/python/ecl/eclfile/fortio.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'fortio.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Module to support transparent binary IO of Fortran created files.
 

--- a/python/ecl/gravimetry/__init__.py
+++ b/python/ecl/gravimetry/__init__.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 """
   ecl_grav/EclGrav: Class used to simplify evaluation of ECLIPSE
      modelling time-lapse gravitational surveys.

--- a/python/ecl/gravimetry/ecl_grav.py
+++ b/python/ecl/gravimetry/ecl_grav.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_grav.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Calculate dynamic change in gravitational strength.
 

--- a/python/ecl/gravimetry/ecl_grav_calc.py
+++ b/python/ecl/gravimetry/ecl_grav_calc.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl import EclPrototype
 
 __arglist = "double, double, double, "

--- a/python/ecl/gravimetry/ecl_subsidence.py
+++ b/python/ecl/gravimetry/ecl_subsidence.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_subsidence.py' is part of ERT - Ensemble based
-#  Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Calculate dynamic change in gravitational strength.
 

--- a/python/ecl/grid/__init__.py
+++ b/python/ecl/grid/__init__.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 """
   ecl_grid/EclGrid: This will load an ECLIPSE GRID or EGRID file, and
      can then subsequently be used for queries about the grid.

--- a/python/ecl/grid/cell.py
+++ b/python/ecl/grid/cell.py
@@ -1,21 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
-
 class Cell(object):
     def __init__(self, grid, global_index):
         self._grid = grid

--- a/python/ecl/grid/ecl_grid.py
+++ b/python/ecl/grid/ecl_grid.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_grid.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 """
 Module to load and query ECLIPSE GRID/EGRID files.
 

--- a/python/ecl/grid/ecl_grid_generator.py
+++ b/python/ecl/grid/ecl_grid_generator.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  The file 'ecl_grid_generator.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import itertools, numpy
 from math import sqrt
 

--- a/python/ecl/grid/ecl_region.py
+++ b/python/ecl/grid/ecl_region.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_region.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Module used to select cells based on many different criteria.
 

--- a/python/ecl/grid/faults/fault.py
+++ b/python/ecl/grid/faults/fault.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'fault.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import numpy as np
 
 from ecl.util.util import monkey_the_camel

--- a/python/ecl/grid/faults/fault_block.py
+++ b/python/ecl/grid/faults/fault_block.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'fault_block.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import ctypes
 from cwrap import BaseCClass
 

--- a/python/ecl/grid/faults/fault_block_collection.py
+++ b/python/ecl/grid/faults/fault_block_collection.py
@@ -1,20 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'fault_block_collection.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
-
 from cwrap import BaseCClass
 
 from ecl.util.util import monkey_the_camel

--- a/python/ecl/grid/faults/fault_block_layer.py
+++ b/python/ecl/grid/faults/fault_block_layer.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'fault_block_layer.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from __future__ import print_function
 from cwrap import BaseCClass
 

--- a/python/ecl/grid/faults/fault_collection.py
+++ b/python/ecl/grid/faults/fault_collection.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'fault_collection.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import re
 
 from ecl.util.util import monkey_the_camel

--- a/python/ecl/grid/faults/fault_line.py
+++ b/python/ecl/grid/faults/fault_line.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'fault_line.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import sys
 
 from ecl.util.util import monkey_the_camel

--- a/python/ecl/grid/faults/fault_segments.py
+++ b/python/ecl/grid/faults/fault_segments.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2014.  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify it under the
-#  terms of the GNU General Public License as published by the Free Software
-#  Foundation, either version 3 of the License, or (at your option) any later
-#  version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-#  A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from __future__ import print_function
 
 from ecl.util.util import monkey_the_camel

--- a/python/ecl/grid/faults/layer.py
+++ b/python/ecl/grid/faults/layer.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'layer.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import ctypes
 
 from ecl.grid import EclGrid

--- a/python/ecl/rft/__init__.py
+++ b/python/ecl/rft/__init__.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 """
   ecl_rft/[EclRFTFile , EclRFT , EclRFTCell]: Loads an ECLIPSE RFT/PLT
      file, and can afterwords be used to support various queries.

--- a/python/ecl/rft/ecl_rft.py
+++ b/python/ecl/rft/ecl_rft.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_rft.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Module for loading ECLIPSE RFT files.
 """

--- a/python/ecl/rft/ecl_rft_cell.py
+++ b/python/ecl/rft/ecl_rft_cell.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_rft_cell.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from cwrap import BaseCClass
 from ecl import EclPrototype
 

--- a/python/ecl/rft/well_trajectory.py
+++ b/python/ecl/rft/well_trajectory.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'well_trajectory.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import sys
 from os.path import isfile
 from collections import namedtuple

--- a/python/ecl/summary/__init__.py
+++ b/python/ecl/summary/__init__.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 """
   ecl_sum/EclSum: This will load summary results from an ECLIPSE run;
      both data file(s) and the SMSPEC file. The EclSum object can be

--- a/python/ecl/summary/ecl_cmp.py
+++ b/python/ecl/summary/ecl_cmp.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'ecl_cmp.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl.util.util import monkey_the_camel
 from ecl.summary import EclSum
 

--- a/python/ecl/summary/ecl_npv.py
+++ b/python/ecl/summary/ecl_npv.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2013  Equinor ASA, Norway.
-#
-#  The file 'ecl_npv.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import re
 import datetime
 import numbers

--- a/python/ecl/summary/ecl_smspec_node.py
+++ b/python/ecl/summary/ecl_smspec_node.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2016  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from cwrap import BaseCClass
 from ecl.util.util import monkey_the_camel
 from ecl import EclPrototype

--- a/python/ecl/summary/ecl_sum.py
+++ b/python/ecl/summary/ecl_sum.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_sum.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Module for loading and querying summary data.
 

--- a/python/ecl/summary/ecl_sum_keyword_vector.py
+++ b/python/ecl/summary/ecl_sum_keyword_vector.py
@@ -1,20 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ecl_sum_keyword_vector.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
-
 import numpy
 import datetime
 

--- a/python/ecl/summary/ecl_sum_tstep.py
+++ b/python/ecl/summary/ecl_sum_tstep.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from cwrap import BaseCClass
 
 from ecl.util.util import monkey_the_camel

--- a/python/ecl/summary/ecl_sum_var_type.py
+++ b/python/ecl/summary/ecl_sum_var_type.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2016  Equinor ASA, Norway.
-#
-#  The file 'ecl_sum_var_type.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from cwrap import BaseCEnum
 
 

--- a/python/ecl/summary/ecl_sum_vector.py
+++ b/python/ecl/summary/ecl_sum_vector.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from __future__ import print_function
 import warnings
 from ecl.summary.ecl_sum_node import EclSumNode

--- a/python/ecl/util/geometry/__init__.py
+++ b/python/ecl/util/geometry/__init__.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file '__init__.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Simple package for working with 2D geometry.
 

--- a/python/ecl/util/geometry/cpolyline.py
+++ b/python/ecl/util/geometry/cpolyline.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011 Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify it under the
-#  terms of the GNU General Public License as published by the Free Software
-#  Foundation, either version 3 of the License, or (at your option) any later
-#  version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-#  A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Create a polygon
 """

--- a/python/ecl/util/geometry/cpolyline_collection.py
+++ b/python/ecl/util/geometry/cpolyline_collection.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'cpolyline_collection.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Create a polygon
 """

--- a/python/ecl/util/geometry/geo_pointset.py
+++ b/python/ecl/util/geometry/geo_pointset.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from cwrap import BaseCClass
 from ecl import EclPrototype
 

--- a/python/ecl/util/geometry/geo_region.py
+++ b/python/ecl/util/geometry/geo_region.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from cwrap import BaseCClass
 from ecl.util.util import IntVector
 from ecl import EclPrototype

--- a/python/ecl/util/geometry/surface.py
+++ b/python/ecl/util/geometry/surface.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2016  Equinor ASA, Norway.
-#
-#  The file 'surface' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from __future__ import division
 
 """

--- a/python/ecl/util/test/ert_test_context.py
+++ b/python/ecl/util/test/ert_test_context.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2013  Equinor ASA, Norway.
-#
-#  The file 'test_work_area.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import os.path
 
 from cwrap import BaseCClass

--- a/python/ecl/util/test/import_test_case.py
+++ b/python/ecl/util/test/import_test_case.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2017 Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import importlib
 import inspect
 import os

--- a/python/ecl/util/test/lint_test_case.py
+++ b/python/ecl/util/test/lint_test_case.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2017 Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import sys
 import fnmatch
 import os

--- a/python/ecl/util/test/test_area.py
+++ b/python/ecl/util/test/test_area.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2013  Equinor ASA, Norway.
-#
-#  The file 'test_work_area.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import os.path
 
 from cwrap import BaseCClass

--- a/python/ecl/util/test/test_run.py
+++ b/python/ecl/util/test/test_run.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2013  Equinor ASA, Norway.
-#
-#  The file 'test_run.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, teither version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import random
 import os.path
 import subprocess

--- a/python/ecl/util/util/__init__.py
+++ b/python/ecl/util/util/__init__.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file '__init__.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Package with utility classes, used by other ERT classes.
 

--- a/python/ecl/util/util/arg_pack.py
+++ b/python/ecl/util/util/arg_pack.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'arg_pack.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from cwrap import BaseCClass
 from ecl import EclPrototype
 

--- a/python/ecl/util/util/bool_vector.py
+++ b/python/ecl/util/util/bool_vector.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'vector_template.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl import EclPrototype
 from ecl.util.util import VectorTemplate
 

--- a/python/ecl/util/util/cthread_pool.py
+++ b/python/ecl/util/util/cthread_pool.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'cthread_pool.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import ctypes
 
 from cwrap import BaseCClass

--- a/python/ecl/util/util/ctime.py
+++ b/python/ecl/util/util/ctime.py
@@ -1,20 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'ctime.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
-
 import ctypes
 import datetime
 import time

--- a/python/ecl/util/util/double_vector.py
+++ b/python/ecl/util/util/double_vector.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'double_vector.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl import EclPrototype
 from ecl.util.util import VectorTemplate
 

--- a/python/ecl/util/util/hash.py
+++ b/python/ecl/util/util/hash.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'hash.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from ctypes import c_void_p
 
 from cwrap import BaseCClass

--- a/python/ecl/util/util/int_vector.py
+++ b/python/ecl/util/util/int_vector.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'int_vector.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl import EclPrototype
 from ecl.util.util import VectorTemplate
 

--- a/python/ecl/util/util/lookup_table.py
+++ b/python/ecl/util/util/lookup_table.py
@@ -1,20 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'lookup_table.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
-
 from cwrap import BaseCClass
 from ecl import EclPrototype
 

--- a/python/ecl/util/util/rng.py
+++ b/python/ecl/util/util/rng.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'rng.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import os.path
 
 from cwrap import BaseCClass

--- a/python/ecl/util/util/stringlist.py
+++ b/python/ecl/util/util/stringlist.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'stringlist.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Simple wrapping of stringlist 'class' from C library.
 

--- a/python/ecl/util/util/time_vector.py
+++ b/python/ecl/util/util/time_vector.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'vector_template.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import datetime
 import re
 

--- a/python/ecl/util/util/util_func.py
+++ b/python/ecl/util/util/util_func.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'util_func.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Module with utility functions from util.c
 """

--- a/python/ecl/util/util/vector_template.py
+++ b/python/ecl/util/util/vector_template.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'vector_template.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 """
 Typed vectors IntVector, DoubleVector and BoolVector.
 

--- a/python/ecl/well/well_info.py
+++ b/python/ecl/well/well_info.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from os.path import isfile
 from cwrap import BaseCClass
 from ecl.grid import EclGrid

--- a/python/tests/bin_tests/test_summary_resample.py
+++ b/python/tests/bin_tests/test_summary_resample.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import os.path
 import subprocess
 from subprocess import CalledProcessError as CallError

--- a/python/tests/ecl_tests/test_cell.py
+++ b/python/tests/ecl_tests/test_cell.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl.grid import Cell, EclGrid
 from tests import EclTest
 from unittest import skipUnless

--- a/python/tests/ecl_tests/test_debug.py
+++ b/python/tests/ecl_tests/test_debug.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  The file 'test_debug.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl.util.test import debug_msg
 from tests import EclTest
 

--- a/python/tests/ecl_tests/test_deprecation.py
+++ b/python/tests/ecl_tests/test_deprecation.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'test_deprecation.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import warnings
 import time
 import datetime

--- a/python/tests/ecl_tests/test_ecl_3dkw.py
+++ b/python/tests/ecl_tests/test_ecl_3dkw.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'test_kw.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import os
 import random
 

--- a/python/tests/ecl_tests/test_ecl_cmp.py
+++ b/python/tests/ecl_tests/test_ecl_cmp.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'test_ecl_cmp.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl.util.test import TestAreaContext
 from ecl.util.test.ecl_mock import createEclSum
 from ecl.summary import EclCmp

--- a/python/tests/ecl_tests/test_ecl_file.py
+++ b/python/tests/ecl_tests/test_ecl_file.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import shutil
 import datetime
 import os.path

--- a/python/tests/ecl_tests/test_ecl_file_equinor.py
+++ b/python/tests/ecl_tests/test_ecl_file_equinor.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import datetime
 import os.path
 from unittest import skipIf

--- a/python/tests/ecl_tests/test_ecl_init_file.py
+++ b/python/tests/ecl_tests/test_ecl_init_file.py
@@ -1,20 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'test_ecl_init_file.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
-
 from tests import EclTest, equinor_test
 from ecl import EclFileFlagEnum
 from ecl.eclfile import Ecl3DKW, EclKW, EclInitFile, EclFile, FortIO

--- a/python/tests/ecl_tests/test_ecl_kw.py
+++ b/python/tests/ecl_tests/test_ecl_kw.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'test_kw.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import random
 import warnings
 import cwrap

--- a/python/tests/ecl_tests/test_ecl_kw_equinor.py
+++ b/python/tests/ecl_tests/test_ecl_kw_equinor.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'test_kw.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import os
 import random
 from ecl import EclDataType, EclFileFlagEnum

--- a/python/tests/ecl_tests/test_ecl_restart_file.py
+++ b/python/tests/ecl_tests/test_ecl_restart_file.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'test_ecl_init_file.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import datetime
 
 from tests import EclTest, equinor_test

--- a/python/tests/ecl_tests/test_ecl_sum.py
+++ b/python/tests/ecl_tests/test_ecl_sum.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'test_ecl_sum.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import datetime
 import os.path
 

--- a/python/tests/ecl_tests/test_ecl_sum_vector.py
+++ b/python/tests/ecl_tests/test_ecl_sum_vector.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2013  Equinor ASA, Norway.
-#
-#  The file 'test_ecl_sum_vector.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 try:
     from unittest2 import skipIf
 except ImportError:

--- a/python/tests/ecl_tests/test_ecl_util.py
+++ b/python/tests/ecl_tests/test_ecl_util.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl import EclTypeEnum, EclFileEnum, EclPhaseEnum, EclUnitTypeEnum, EclUtil
 from ecl.grid import EclGrid
 from tests import EclTest

--- a/python/tests/ecl_tests/test_equinor_faults.py
+++ b/python/tests/ecl_tests/test_equinor_faults.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'test_faults.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 try:
     from unittest2 import skipIf
 except ImportError:

--- a/python/tests/ecl_tests/test_fault_blocks.py
+++ b/python/tests/ecl_tests/test_fault_blocks.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'test_fault_blocks.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from unittest import skipIf
 import cwrap
 

--- a/python/tests/ecl_tests/test_fault_blocks_equinor.py
+++ b/python/tests/ecl_tests/test_fault_blocks_equinor.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'test_fault_blocks.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 try:
     from unittest2 import skipIf
 except ImportError:

--- a/python/tests/ecl_tests/test_faults.py
+++ b/python/tests/ecl_tests/test_faults.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'test_faults.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from unittest import skipIf
 import time
 from ecl import util

--- a/python/tests/ecl_tests/test_fk_user_data.py
+++ b/python/tests/ecl_tests/test_fk_user_data.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  The file 'test_ecl_cell_containment.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl.grid import EclGrid
 from ecl.util.test import TestAreaContext
 from tests import EclTest

--- a/python/tests/ecl_tests/test_fortio.py
+++ b/python/tests/ecl_tests/test_fortio.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import os
 import cwrap
 from random import randint

--- a/python/tests/ecl_tests/test_grdecl.py
+++ b/python/tests/ecl_tests/test_grdecl.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  The file 'test_grdecl.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from numpy import allclose
 
 import cwrap

--- a/python/tests/ecl_tests/test_grdecl_equinor.py
+++ b/python/tests/ecl_tests/test_grdecl_equinor.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import os
 from ecl.eclfile import EclKW, Ecl3DKW
 from ecl.grid import EclGrid

--- a/python/tests/ecl_tests/test_grid.py
+++ b/python/tests/ecl_tests/test_grid.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'test_grid.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import os.path
 from unittest import skip
 import itertools

--- a/python/tests/ecl_tests/test_grid_equinor.py
+++ b/python/tests/ecl_tests/test_grid_equinor.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'test_grid.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import math
 
 try:

--- a/python/tests/ecl_tests/test_grid_equinor_coarse.py
+++ b/python/tests/ecl_tests/test_grid_equinor_coarse.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  The file 'test_grid_equinor_coarse.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import itertools
 
 from ecl.eclfile import EclRestartFile

--- a/python/tests/ecl_tests/test_grid_equinor_dual.py
+++ b/python/tests/ecl_tests/test_grid_equinor_dual.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  The file 'test_grid_equinor_dual.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import math
 
 from ecl.util.test import TestAreaContext

--- a/python/tests/ecl_tests/test_grid_generator.py
+++ b/python/tests/ecl_tests/test_grid_generator.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  The file 'test_grid_generator.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from itertools import product as prod
 import operator
 import random

--- a/python/tests/ecl_tests/test_grid_pandas.py
+++ b/python/tests/ecl_tests/test_grid_pandas.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2018  Equinor ASA, Norway.
-#
-#  The file 'test_grid.pandas' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import numpy as np
 import pandas as pd
 

--- a/python/tests/ecl_tests/test_kw_function.py
+++ b/python/tests/ecl_tests/test_kw_function.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'test_kw_function.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import os
 import random
 from ecl import EclDataType

--- a/python/tests/ecl_tests/test_layer.py
+++ b/python/tests/ecl_tests/test_layer.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'test_layer.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from unittest import skipIf
 import time
 

--- a/python/tests/ecl_tests/test_npv.py
+++ b/python/tests/ecl_tests/test_npv.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import os
 import datetime
 import math

--- a/python/tests/ecl_tests/test_region.py
+++ b/python/tests/ecl_tests/test_region.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2017  Equinor ASA, Norway.
-#
-#  The file 'test_region.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from ecl import EclDataType
 from ecl.eclfile import EclKW
 from ecl.grid import EclGrid, EclRegion

--- a/python/tests/ecl_tests/test_region_equinor.py
+++ b/python/tests/ecl_tests/test_region_equinor.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2012  Equinor ASA, Norway.
-#
-#  The file 'test_region.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from ecl.eclfile import EclFile
 from ecl.grid import EclGrid, EclRegion
 from ecl.grid.faults import Layer

--- a/python/tests/ecl_tests/test_restart.py
+++ b/python/tests/ecl_tests/test_restart.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 from _ctypes import ArgumentError
 import os
 import datetime

--- a/python/tests/ecl_tests/test_restart_head.py
+++ b/python/tests/ecl_tests/test_restart_head.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'test_ecl_init_file.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import datetime
 
 from tests import EclTest, equinor_test

--- a/python/tests/ecl_tests/test_rft.py
+++ b/python/tests/ecl_tests/test_rft.py
@@ -1,21 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2016  Equinor ASA, Norway.
-#
-#  The file 'test_rft.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
-
 import datetime
 from ecl.util.util import CTime
 from ecl.rft import EclRFTFile, EclRFTCell, EclPLTCell, EclRFT, WellTrajectory

--- a/python/tests/ecl_tests/test_rft_cell.py
+++ b/python/tests/ecl_tests/test_rft_cell.py
@@ -1,21 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2013  Equinor ASA, Norway.
-#
-#  The file 'test_rft_cell.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
-
 from ecl.rft import EclRFTCell, EclPLTCell
 from tests import EclTest
 

--- a/python/tests/ecl_tests/test_rft_equinor.py
+++ b/python/tests/ecl_tests/test_rft_equinor.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'test_rft_equinor.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from __future__ import print_function
 import datetime
 from ecl.rft import EclRFTFile, EclRFTCell, EclPLTCell, WellTrajectory

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import os.path
 import os
 import inspect

--- a/python/tests/ecl_tests/test_sum_equinor.py
+++ b/python/tests/ecl_tests/test_sum_equinor.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import os
 import datetime
 

--- a/python/tests/global_tests/test_pylint.py
+++ b/python/tests/global_tests/test_pylint.py
@@ -1,19 +1,3 @@
-#  Copyright (C) 2017 Equinor ASA, Norway.
-#
-#  This file is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 from ecl.util.test import LintTestCase
 
 

--- a/python/tests/util_tests/test_vectors.py
+++ b/python/tests/util_tests/test_vectors.py
@@ -1,21 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2011  Equinor ASA, Norway.
-#
-#  The file 'test_vectors.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
-
 import copy
 import datetime
 import six

--- a/python/tests/util_tests/test_version.py
+++ b/python/tests/util_tests/test_version.py
@@ -1,18 +1,3 @@
-#  Copyright (C) 2015  Equinor ASA, Norway.
-#
-#  The file 'test_version.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
 import os.path
 
 import ecl

--- a/python/tests/util_tests/test_work_area.py
+++ b/python/tests/util_tests/test_work_area.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-#  Copyright (C) 2014  Equinor ASA, Norway.
-#
-#  The file 'test_work_area.py' is part of ERT - Ensemble based Reservoir Tool.
-#
-#  ERT is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#  FITNESS FOR A PARTICULAR PURPOSE.
-#
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
-#  for more details.
-
 import os.path
 import os
 


### PR DESCRIPTION
Having such a notice present in every file is visual noise and does not significantly increase protection against copyright infringement.

Edit performed by:

```
for file in `find . -name *.*pp`; do
    perl -0 -p -i -e 's/\/\*.*Copyright.*?\*\/\s*//is' $file
done

for file in `find . -name "*.py"`; do
    perl -0 -p -i -e 's/#\s+Copyright.*#\s+for more details.\s*//s' $file
done
```
