### PR TITLE
Pin windows compile to windows-2019 image

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest']
+        os: ['windows-2019']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.11.0'
 
     - name: Install dependencies
       run: pip install conan


### PR DESCRIPTION
Last 2022-image that works is 20221127.1. Not possible to pin to this image exactly. First 2022-image that fails is 20221215.2