### PR TITLE
Move ci functions to this repo

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -1,3 +1,25 @@
+function ci_install_cmake {
+    pip install cmake ninja
+
+    local root=${KOMODO_ROOT}/${CI_KOMODO_RELEASE}/root
+
+    export CMAKE_GENERATOR=Ninja
+    export CMAKE_PREFIX_PATH=$root
+
+    # Colour!
+    export CFLAGS="${CFLAGS:-} -fdiagnostics-color=always"
+    export CXXFLAGS="${CXXFLAGS:-} -fdiagnostics-color=always"
+    export LDFLAGS="${LDFLAGS:-} -fdiagnostics-color=always"
+
+    export LD_LIBRARY_PATH=$root/lib:$root/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+}
+function ci_install_conan {
+    pip install "conan<2"
+
+    # Conan v1 bundles its own certs due to legacy reasons, so we point it
+    # to the system's certs instead.
+    export CONAN_CACERT_PATH=/etc/pki/tls/cert.pem
+}
 build_and_run_ctest () {
     pushd $CI_TEST_ROOT
     cmake $CI_SOURCE_ROOT                                  \

--- a/python/docs/examples/cmp_nnc.py
+++ b/python/docs/examples/cmp_nnc.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         nnc_list.append((g1, g2, t))
 
     nnc_list = sorted(nnc_list, key=itemgetter(0))
-    for (g1, g2, T) in nnc_list:
+    for g1, g2, T in nnc_list:
         # grid_ijk assumes 0-based indexing, g1/g2 are 1-based (FORTRAN)
         # Convert them to zero based ones.
         g1 = g1 - 1

--- a/python/ecl/ecl_type.py
+++ b/python/ecl/ecl_type.py
@@ -25,7 +25,6 @@ EclTypeEnum.addEnum("ECL_STRING_TYPE", 7)
 
 
 class EclDataType(BaseCClass):
-
     TYPE_NAME = "ecl_data_type"
 
     _alloc = EclPrototype(

--- a/python/ecl/eclfile/fortio.py
+++ b/python/ecl/eclfile/fortio.py
@@ -148,7 +148,6 @@ class FortIO(BaseCClass):
 
     @classmethod
     def is_fortran_file(cls, filename, endian_flip=True):
-
         """@rtype: bool
         @type filename: str
 

--- a/python/ecl/gravimetry/ecl_grav_calc.py
+++ b/python/ecl/gravimetry/ecl_grav_calc.py
@@ -69,7 +69,7 @@ def deltag(xyz, grid, init_file, restart_file1, restart_file2):
     porv2 = restart_file2.iget_named_kw("RPORV", 0)
 
     deltag = 0
-    for (sat1, sat2) in phase_list:
+    for sat1, sat2 in phase_list:
         rho_name = "%s_DEN" % sat1.name[1:]
         rho1 = restart_file1.iget_named_kw(rho_name, 0)
         rho2 = restart_file2.iget_named_kw(rho_name, 0)

--- a/python/ecl/grid/ecl_grid.py
+++ b/python/ecl/grid/ecl_grid.py
@@ -232,7 +232,6 @@ class EclGrid(BaseCClass):
 
     @classmethod
     def create(cls, specgrid, zcorn, coord, actnum, mapaxes=None):
-
         """
         Create a new grid instance from existing keywords.
 
@@ -277,7 +276,7 @@ class EclGrid(BaseCClass):
         else:
             if not isinstance(actnum, IntVector):
                 tmp = IntVector(initial_size=len(actnum))
-                for (index, value) in enumerate(actnum):
+                for index, value in enumerate(actnum):
                     tmp[index] = value
                 actnum = tmp
 
@@ -1016,7 +1015,6 @@ class EclGrid(BaseCClass):
         return (dx, dy, dz)
 
     def get_num_lgr(self):
-
         """
         How many LGRs are attached to this main grid?
 

--- a/python/ecl/grid/ecl_grid_generator.py
+++ b/python/ecl/grid/ecl_grid_generator.py
@@ -50,7 +50,6 @@ def pre_mapaxes_translation(translation, mapaxes):
 
 
 class EclGridGenerator:
-
     _alloc_rectangular = EclPrototype(
         "ecl_grid_obj ecl_grid_alloc_rectangular(int, int, int, double, double, double, int*)",
         bind=False,
@@ -70,7 +69,7 @@ class EclGridGenerator:
         else:
             if not isinstance(actnum, IntVector):
                 tmp = IntVector(initial_size=len(actnum))
-                for (index, value) in enumerate(actnum):
+                for index, value in enumerate(actnum):
                     tmp[index] = value
                 actnum = tmp
 
@@ -137,7 +136,6 @@ class EclGridGenerator:
         concave=False,
         faults=False,
     ):
-
         cls.__assert_zcorn_parameters(
             dims,
             dV,
@@ -194,7 +192,6 @@ class EclGridGenerator:
         rotate=False,
         misalign=False,
     ):
-
         nx, ny, nz = dims
         dx, dy, dz = dV
 
@@ -236,7 +233,6 @@ class EclGridGenerator:
         concave,
         faults,
     ):
-
         nx, ny, nz = dims
         dx, dy, dz = dV
 
@@ -588,7 +584,6 @@ class EclGridGenerator:
     def extract_subgrid(
         cls, grid, ijk_bounds, decomposition_change=False, translation=None
     ):
-
         """
         Extracts a subgrid from the given grid according to the specified
         bounds.

--- a/python/ecl/grid/ecl_region.py
+++ b/python/ecl/grid/ecl_region.py
@@ -987,7 +987,6 @@ class EclRegion(BaseCClass):
     #################################################################
 
     def scalar_apply_kw(self, target_kw, scalar, func_dict, force_active=False):
-
         """
         Helper function to apply a function with one scalar arg on target_kw.
         """

--- a/python/ecl/grid/faults/fault.py
+++ b/python/ecl/grid/faults/fault.py
@@ -100,7 +100,7 @@ class FaultLayer(object):
         perm_list.sort(key=lambda x: x[1])
 
         fault_lines = []
-        for (index, d) in perm_list:
+        for index, d in perm_list:
             fault_lines.append(self.__fault_lines[index])
         self.__fault_lines = fault_lines
 

--- a/python/ecl/grid/faults/fault_block.py
+++ b/python/ecl/grid/faults/fault_block.py
@@ -133,7 +133,7 @@ class FaultBlock(BaseCClass):
 
         self._trace_edge(x_list, y_list, cell_list)
         p = Polyline()
-        for (x, y) in zip(x_list, y_list):
+        for x, y in zip(x_list, y_list):
             p.addPoint(x, y)
         return p
 

--- a/python/ecl/grid/faults/fault_line.py
+++ b/python/ecl/grid/faults/fault_line.py
@@ -89,7 +89,7 @@ class FaultLine(object):
 
     def __init_polyline(self):
         pl = CPolyline()
-        for (i, j) in self.getIJPolyline():
+        for i, j in self.getIJPolyline():
             x, y, z = self.__grid.getNodeXYZ(i, j, self.__k)
             pl.addPoint(x, y)
         self.__polyline = pl

--- a/python/ecl/grid/faults/fault_segments.py
+++ b/python/ecl/grid/faults/fault_segments.py
@@ -68,7 +68,7 @@ class SegmentMap(object):
         return self.__segment_map.__str__()
 
     def verify(self):
-        for (C, count) in self.__count_map.iteritems():
+        for C, count in self.__count_map.iteritems():
             if count > 0:
                 d = self.__segment_map[C]
                 if len(d) != count:
@@ -112,7 +112,7 @@ class SegmentMap(object):
 
     def pop_start(self):
         end_segments = []
-        for (C, count) in self.__count_map.items():
+        for C, count in self.__count_map.items():
             if count == 1:
                 end_segments.append(list(self.__segment_map[C].values())[0])
 
@@ -135,7 +135,7 @@ class SegmentMap(object):
 
     def print_content(self):
         for d in self.__segment_map.values():
-            for (C, S) in d.iteritems():
+            for C, S in d.iteritems():
                 print(S)
 
 

--- a/python/ecl/grid/faults/layer.py
+++ b/python/ecl/grid/faults/layer.py
@@ -241,7 +241,7 @@ class Layer(BaseCClass):
         j_list = IntVector()
         self._cells_equal(value, i_list, j_list)
         ij_list = []
-        for (i, j) in zip(i_list, j_list):
+        for i, j in zip(i_list, j_list):
             ij_list.append((i, j))
         return ij_list
 

--- a/python/ecl/summary/ecl_npv.py
+++ b/python/ecl/summary/ecl_npv.py
@@ -160,7 +160,7 @@ class EclNPV(object):
         self.code = (
             "trange = self.baseCase.timeRange(self.start, self.end, self.interval)\n"
         )
-        for (key, var) in self.keyList.items():
+        for key, var in self.keyList.items():
             self.code += '%s = self.baseCase.blockedProduction("%s", trange)\n' % (
                 var,
                 key,

--- a/python/ecl/summary/ecl_sum.py
+++ b/python/ecl/summary/ecl_sum.py
@@ -825,7 +825,6 @@ are advised to fetch vector as a numpy vector and then scale that yourself:
         return self._check_sim_time(date)
 
     def get_interp_direct(self, key, date):
-
         if not isinstance(date, CTime):
             date = CTime(date)
         return self._get_general_var_from_sim_time(date, key)
@@ -853,7 +852,6 @@ are advised to fetch vector as a numpy vector and then scale that yourself:
             if self.check_sim_time(t):
                 return self._get_general_var_from_sim_time(t, key)
             else:
-
                 raise ValueError("date:%s is outside range of simulation data" % date)
         elif date is None:
             if self._check_sim_days(days):

--- a/python/ecl/util/geometry/cpolyline.py
+++ b/python/ecl/util/geometry/cpolyline.py
@@ -38,7 +38,7 @@ class CPolyline(BaseCClass):
     def __init__(self, name=None, init_points=()):
         c_ptr = self._alloc_new(name)
         super(CPolyline, self).__init__(c_ptr)
-        for (xc, yc) in init_points:
+        for xc, yc in init_points:
             self.addPoint(xc, yc)
 
     @classmethod

--- a/python/ecl/util/geometry/geometry_tools.py
+++ b/python/ecl/util/geometry/geometry_tools.py
@@ -394,17 +394,13 @@ class GeometryTools(object):
         p0 = polyline[-1]
         p1 = polyline[-2]
         ray = GeometryTools.lineToRay(p1, p0)
-        for (index, p) in GeometryTools.rayPolygonIntersections(
-            p0, ray, target_polyline
-        ):
+        for index, p in GeometryTools.rayPolygonIntersections(p0, ray, target_polyline):
             d_list.append((GeometryTools.distance(p0, p), [p0, p]))
 
         p0 = polyline[0]
         p1 = polyline[1]
         ray = GeometryTools.lineToRay(p1, p0)
-        for (index, p) in GeometryTools.rayPolygonIntersections(
-            p0, ray, target_polyline
-        ):
+        for index, p in GeometryTools.rayPolygonIntersections(p0, ray, target_polyline):
             d_list.append((GeometryTools.distance(p0, p), [p0, p]))
 
         if len(d_list) == 0:

--- a/python/ecl/util/geometry/polyline.py
+++ b/python/ecl/util/geometry/polyline.py
@@ -40,7 +40,7 @@ class Polyline(object):
         if len(self) != len(other):
             return False
 
-        for (p1, p2) in zip(self, other):
+        for p1, p2 in zip(self, other):
             if p1 != p2:
                 return False
 

--- a/python/ecl/util/geometry/surface.py
+++ b/python/ecl/util/geometry/surface.py
@@ -177,7 +177,6 @@ class Surface(BaseCClass):
         return self._copy(copy_data)
 
     def write(self, filename):
-
         """
         Will write the surface as an ascii formatted file to @filename.
         """

--- a/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
+++ b/python/ecl/util/test/ecl_mock/ecl_sum_mock.py
@@ -19,12 +19,11 @@ def createEclSum(
     restart_case=None,
     restart_step=-1,
 ):
-
     ecl_sum = EclSum.restart_writer(
         case, restart_case, restart_step, sim_start, dims[0], dims[1], dims[2]
     )
     var_list = []
-    for (kw, wgname, num, unit) in keys:
+    for kw, wgname, num, unit in keys:
         var_list.append(ecl_sum.addVariable(kw, wgname=wgname, num=num, unit=unit))
 
     # This is a bug! This should not be integer division, but tests are written

--- a/python/ecl/util/test/ert_test_runner.py
+++ b/python/ecl/util/test/ert_test_runner.py
@@ -19,7 +19,7 @@ class ErtTestRunner(object):
         loader = TestLoader()
         test_suite = loader.discover(path, pattern=pattern)
 
-        for (root, dirnames, filenames) in os.walk(path):
+        for root, dirnames, filenames in os.walk(path):
             for directory in dirnames:
                 test_suite.addTests(
                     ErtTestRunner.findTestsInDirectory(

--- a/python/ecl/util/test/extended_testcase.py
+++ b/python/ecl/util/test/extended_testcase.py
@@ -178,7 +178,6 @@ class ExtendedTestCase(TestCase):
         return os.path.realpath(os.path.join(cls.TESTDATA_ROOT, path))
 
     def assertNotRaises(self, func=None):
-
         context = _AssertNotRaisesContext(self)
         if func is None:
             return context

--- a/python/ecl/util/test/test_area.py
+++ b/python/ecl/util/test/test_area.py
@@ -5,7 +5,6 @@ from ecl import EclPrototype
 
 
 class TestArea(BaseCClass):
-
     __test__ = False
 
     _test_area_alloc = EclPrototype(
@@ -34,7 +33,6 @@ class TestArea(BaseCClass):
     )
 
     def __init__(self, test_name, store_area=False, c_ptr=None):
-
         if c_ptr is None:
             c_ptr = self._test_area_alloc(test_name, store_area)
 
@@ -107,7 +105,6 @@ class TestArea(BaseCClass):
 
 
 class TestAreaContext(object):
-
     __test__ = False
 
     def __init__(self, test_name, store_area=False):

--- a/python/ecl/util/test/test_run.py
+++ b/python/ecl/util/test/test_run.py
@@ -126,7 +126,7 @@ class TestRun(object):
 
                 status_list = [status]
                 if status[0]:
-                    for (check_func, arg) in self.check_list:
+                    for check_func, arg in self.check_list:
                         status = check_func(arg)
                         status_list.append(status)
                         if not status[0]:

--- a/python/ecl/util/util/vector_template.py
+++ b/python/ecl/util/util/vector_template.py
@@ -517,7 +517,7 @@ class VectorTemplate(BaseCClass):
 
     def asList(self):
         l = [0] * len(self)
-        for (index, value) in enumerate(self):
+        for index, value in enumerate(self):
             l[index] = value
 
         return l

--- a/python/tests/ecl_tests/test_ecl_kw.py
+++ b/python/tests/ecl_tests/test_ecl_kw.py
@@ -61,7 +61,7 @@ class KWTest(EclTest):
         name1 = "file1.txt"
         name2 = "file2.txt"
         kw = EclKW("TEST", len(data), data_type)
-        for (i, d) in enumerate(data):
+        for i, d in enumerate(data):
             kw[i] = d
 
         file1 = cwrap.open(name1, "w")
@@ -138,7 +138,6 @@ class KWTest(EclTest):
 
     def test_kw_write(self):
         with TestAreaContext("python/ecl_kw/writing"):
-
             data = [random.random() for i in range(10000)]
 
             kw = EclKW("TEST", len(data), EclDataType.ECL_DOUBLE)
@@ -194,7 +193,7 @@ class KWTest(EclTest):
                 for elm in tmp:
                     data.append(int(elm))
 
-            for (v1, v2) in zip(data, kw):
+            for v1, v2 in zip(data, kw):
                 self.assertEqual(v1, v2)
 
     def test_sliced_set(self):
@@ -424,7 +423,6 @@ class KWTest(EclTest):
     def test_string_write_read_unformatted(self):
         for str_len in range(1000):
             with TestAreaContext("my_space"):
-
                 kw = EclKW("TEST_KW", 10, EclDataType.ECL_STRING(str_len))
                 for i in range(10):
                     kw[i] = str(i) * str_len
@@ -442,7 +440,6 @@ class KWTest(EclTest):
     def test_string_write_read_formatted(self):
         for str_len in range(1000):
             with TestAreaContext("my_space"):
-
                 kw = EclKW("TEST_KW", 10, EclDataType.ECL_STRING(str_len))
                 for i in range(10):
                     kw[i] = str(i) * str_len

--- a/python/tests/ecl_tests/test_ecl_type.py
+++ b/python/tests/ecl_tests/test_ecl_type.py
@@ -9,7 +9,6 @@ def get_const_size_types():
 
 
 class EclDataTypeTest(EclTest):
-
     # All of the below should list their elements in the same order as
     # EclTypeEnum!
     # [char, float, double, int, bool, mess]
@@ -39,7 +38,7 @@ class EclDataTypeTest(EclTest):
 
     def test_alloc_from_type(self):
         types, sizes = get_const_size_types(), self.CONST_SIZES
-        for (ecl_type, element_size) in zip(types, sizes):
+        for ecl_type, element_size in zip(types, sizes):
             data_type = EclDataType(ecl_type)
             self.assertEqual(ecl_type, data_type.type)
             self.assertEqual(element_size, data_type.element_size)
@@ -55,20 +54,20 @@ class EclDataTypeTest(EclTest):
             data_type = EclDataType(EclTypeEnum.ECL_STRING_TYPE, 1000)
 
     def test_alloc(self):
-        for (ecl_type, element_size) in zip(self.TYPES, self.SIZES):
+        for ecl_type, element_size in zip(self.TYPES, self.SIZES):
             data_type = EclDataType(ecl_type, element_size)
             self.assertEqual(ecl_type, data_type.type)
             self.assertEqual(element_size, data_type.element_size)
 
     def test_type_verifiers(self):
         test_base = zip(self.TYPES, self.SIZES, self.CONST_VERIFIERS)
-        for (ecl_type, elem_size, verifier) in test_base:
+        for ecl_type, elem_size, verifier in test_base:
             data_type = EclDataType(ecl_type, elem_size)
             self.assertTrue(verifier(data_type))
 
     def test_get_type_name(self):
         test_base = zip(self.TYPES, self.SIZES, self.NAMES)
-        for (ecl_type, elem_size, type_name) in test_base:
+        for ecl_type, elem_size, type_name in test_base:
             data_type = EclDataType(ecl_type, elem_size)
             self.assertEqual(type_name, data_type.type_name)
 
@@ -87,7 +86,7 @@ class EclDataTypeTest(EclTest):
 
     def test_create_from_type_name(self):
         test_base = zip(self.TYPES, self.SIZES, self.NAMES)
-        for (ecl_type, elem_size, type_name) in test_base:
+        for ecl_type, elem_size, type_name in test_base:
             data_type = EclDataType.create_from_type_name(type_name)
             self.assertEqual(ecl_type, data_type.type)
             self.assertEqual(elem_size, data_type.element_size)

--- a/python/tests/ecl_tests/test_fault_blocks.py
+++ b/python/tests/ecl_tests/test_fault_blocks.py
@@ -72,7 +72,6 @@ class FaultBlockTest(EclTest):
             layer[5, 5]
 
     def test_neighbours(self):
-
         with TestAreaContext("python/fault_block_layer/neighbour") as work_area:
             with open("kw.grdecl", "w") as fileH:
                 fileH.write("FAULTBLK \n")

--- a/python/tests/ecl_tests/test_fk_user_data.py
+++ b/python/tests/ecl_tests/test_fk_user_data.py
@@ -6,7 +6,6 @@ from tests import EclTest
 
 class FKTest(EclTest):
     def test_cell_containment(self):
-
         grid_location = "local/ECLIPSE/faarikaal/faarikaal%d.EGRID"
         well_location = "local/ECLIPSE/faarikaal/faarikaal%d.txt"
 

--- a/python/tests/ecl_tests/test_grid_equinor.py
+++ b/python/tests/ecl_tests/test_grid_equinor.py
@@ -173,7 +173,6 @@ class GridTest(EclTest):
 
             with openEclFile("G.EGRID") as f:
                 with copen("grid.grdecl", "a") as f2:
-
                     coord_kw = f["COORD"][0]
                     coord_kw.write_grdecl(f2)
 
@@ -309,7 +308,7 @@ class GridTest(EclTest):
                 "Equinor/ECLIPSE/Troll/MSW_LGR/2BRANCHES-CCEWELLPATH-NEW-SCH-TUNED-AR3.EGRID"
             )
         )
-        for (nr, name) in [
+        for nr, name in [
             (104, "LG003017"),
             (2, "LG006024"),
             (4, "LG005025"),

--- a/python/tests/ecl_tests/test_removed.py
+++ b/python/tests/ecl_tests/test_removed.py
@@ -9,7 +9,6 @@ from ecl.eclfile import EclFile, EclKW, openFortIO, FortIO
 
 class Removed_2_1_Test(EclTest):
     def test_ecl_file_block(self):
-
         with TestAreaContext("name") as t:
             kw = EclKW("TEST", 3, EclDataType.ECL_INT)
             with openFortIO("TEST", mode=FortIO.WRITE_MODE) as f:

--- a/python/tests/ecl_tests/test_sum.py
+++ b/python/tests/ecl_tests/test_sum.py
@@ -357,14 +357,13 @@ class SumTest(EclTest):
                 case1.get_interp("FOPT", date=t),
             ],
         ):
-
             self.assertFloatEqual(d1, d2)
 
         tmp = []
         for key in kw_list:
             tmp.append(key)
 
-        for (k1, k2) in zip(kw_list, tmp):
+        for k1, k2 in zip(kw_list, tmp):
             self.assertEqual(k1, k2)
 
         kw_list2 = kw_list.copy(case2)

--- a/python/tests/ecl_tests/test_sum_equinor.py
+++ b/python/tests/ecl_tests/test_sum_equinor.py
@@ -403,7 +403,7 @@ class SumTest(EclTest):
         fprod = sum.blockedProduction("FOPT", trange)
         gprod = sum.blockedProduction("GOPT:OP", trange)
         wprod = wprod1 + wprod2 + wprod3 + wprod4 + wprod5
-        for (w, f, g) in zip(wprod, fprod, gprod):
+        for w, f, g in zip(wprod, fprod, gprod):
             self.assertFloatEqual(w, f)
             self.assertFloatEqual(w, g)
 
@@ -499,7 +499,6 @@ class SumTest(EclTest):
             "Equinor/ECLIPSE/ix/summary/CREATE_REGION_AROUND_WELL",
             "Equinor/ECLIPSE/ix/troll/IX_NOPH3_R04_75X75X1_GRID2.SMSPEC",
         ]:
-
             with TestAreaContext("my_space" + data_set.split("/")[-1]) as area:
                 intersect_summary = EclSum(
                     self.createTestPath(data_set), lazy_load=False

--- a/python/tests/geometry_tests/test_intersection.py
+++ b/python/tests/geometry_tests/test_intersection.py
@@ -4,7 +4,6 @@ from tests import EclTest
 
 class IntersectionTest(EclTest):
     def test_intersection(self):
-
         p1 = (0.0, 0.0)
         p2 = (10.0, 0.0)
         p3 = (5.0, -5.0)

--- a/python/tests/geometry_tests/test_surface.py
+++ b/python/tests/geometry_tests/test_surface.py
@@ -97,7 +97,6 @@ class SurfaceTest(EclTest):
 
     def test_write(self):
         with TestAreaContext("surface/write"):
-
             s0 = Surface(self.surface_valid)
             s0.write("new_surface.irap")
 

--- a/python/tests/util_tests/test_vectors.py
+++ b/python/tests/util_tests/test_vectors.py
@@ -464,7 +464,7 @@ class UtilTest(TestCase):
         start = datetime.datetime(1980, 1, 1, 0, 0, 0)
         end = datetime.datetime(2020, 1, 1, 0, 0, 0)
         trange = TimeVector.createRegular(start, end, "2Y")
-        for (y, t) in zip(six.moves.xrange(1980, 2022, 2), trange):
+        for y, t in zip(six.moves.xrange(1980, 2022, 2), trange):
             self.assertTrue(t == datetime.datetime(y, 1, 1, 0, 0, 0))
 
         trange = TimeVector.createRegular(start, datetime.date(2050, 1, 1), "1Y")


### PR DESCRIPTION
Only ecl is using these two functions from the komodo repository. Move them into here so that they can be purged from upstream.

**Issue**
Resolves eventually too much code in komodo repository.

**Approach**
Move.